### PR TITLE
Remove automatic change to ABORT_OXIDIZER_PRESSURE

### DIFF
--- a/Src/EngineControl.c
+++ b/Src/EngineControl.c
@@ -32,17 +32,17 @@ void engineControlPrelaunchRoutine(OxidizerTankPressureData* data)
 
         int32_t oxidizerTankPressure = -1;
 
-        if (osMutexWait(data->mutex_, 0) == osOK)
-        {
-            // read tank pressure
-            oxidizerTankPressure = data->pressure_;
-            osMutexRelease(data->mutex_);
+        // if (osMutexWait(data->mutex_, 0) == osOK)
+        // {
+        //     // read tank pressure
+        //     oxidizerTankPressure = data->pressure_;
+        //     osMutexRelease(data->mutex_);
 
-            if (oxidizerTankPressure >= 850 * 1000)
-            {
-                newFlightPhase(ABORT_OXIDIZER_PRESSURE);
-            }
-        }
+        //     if (oxidizerTankPressure >= 850 * 1000)
+        //     {
+        //         newFlightPhase(ABORT_OXIDIZER_PRESSURE);
+        //     }
+        // }
 
         if (launchCmdReceived >= 2 && ARM == getCurrentFlightPhase())
         {

--- a/Src/LogData.c
+++ b/Src/LogData.c
@@ -12,7 +12,7 @@
 
 static int SLOW_LOG_DATA_PERIOD = 1000;
 static int FAST_LOG_DATA_PERIOD = 50;
-static uint8_t softwareVersion = 103;
+static uint8_t softwareVersion = 104;
 
 static FATFS fatfs;
 static FIL file;

--- a/Src/main.c
+++ b/Src/main.c
@@ -114,7 +114,7 @@ uint8_t launchCmdReceived = 0;
 uint8_t abortCmdReceived = 0;
 uint8_t resetAvionicsCmdReceived = 0;
 
-const int32_t HEARTBEAT_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+const int32_t HEARTBEAT_TIMEOUT = 3 * 60 * 1000; // 5 minutes
 int32_t heartbeatTimer = 0; // Initalized to HEARTBEAT_TIMEOUT in MonitorForEmergencyShutoff thread
 
 static const int FLIGHT_PHASE_DISPLAY_FREQ = 1000;

--- a/Src/main.c
+++ b/Src/main.c
@@ -114,7 +114,7 @@ uint8_t launchCmdReceived = 0;
 uint8_t abortCmdReceived = 0;
 uint8_t resetAvionicsCmdReceived = 0;
 
-const int32_t HEARTBEAT_TIMEOUT = 3 * 60 * 1000; // 5 minutes
+const int32_t HEARTBEAT_TIMEOUT = 3 * 60 * 1000; // 3 minutes
 int32_t heartbeatTimer = 0; // Initalized to HEARTBEAT_TIMEOUT in MonitorForEmergencyShutoff thread
 
 static const int FLIGHT_PHASE_DISPLAY_FREQ = 1000;


### PR DESCRIPTION
Only allow Ground Systems to control when we go to ABORT (other than
communication errors). This was decided by everyone else because they
want control over the flight phase even when the pressure sensor is
malfunctioning. If we lose communication and the pressure goes high, we
have to wait 3 mins before we go to ABORT because there is no other way
to get there.