### PR TITLE
Clang Format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,182 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/Core/Inc/AbortPhase.h
+++ b/Core/Inc/AbortPhase.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #define ABORT_VALVE_PULSE_MAX_TIME (8000)
 
 extern uint8_t launchCmdReceived;

--- a/Core/Inc/Data.h
+++ b/Core/Inc/Data.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "cmsis_os.h"
+#include "main.h"
+
 /* Structs containing data primitives */
 
 /*
@@ -11,72 +14,64 @@
  * please see the design manual for more information.
  */
 
-typedef struct
-{
-    osMutexId   mutex_;
-    int32_t     accelX_;
-    int32_t     accelY_;
-    int32_t     accelZ_;
-    int32_t     gyroX_;
-    int32_t     gyroY_;
-    int32_t     gyroZ_;
-    int32_t     magnetoX_;
-    int32_t     magnetoY_;
-    int32_t     magnetoZ_;
+typedef struct {
+  osMutexId mutex_;
+  int32_t accelX_;
+  int32_t accelY_;
+  int32_t accelZ_;
+  int32_t gyroX_;
+  int32_t gyroY_;
+  int32_t gyroZ_;
+  int32_t magnetoX_;
+  int32_t magnetoY_;
+  int32_t magnetoZ_;
 } AccelGyroMagnetismData;
 
-typedef struct
-{
-    osMutexId   mutex_;
-    int32_t     pressure_;
-    int32_t     temperature_;
+typedef struct {
+  osMutexId mutex_;
+  int32_t pressure_;
+  int32_t temperature_;
 } BarometerData;
 
-typedef struct
-{
-    osMutexId   mutex_;
-    int32_t     pressure_;
+typedef struct {
+  osMutexId mutex_;
+  int32_t pressure_;
 } CombustionChamberPressureData;
 
-typedef struct
-{
-    osMutexId   mutex_;
-    uint32_t    voltage_; // millivolts
+typedef struct {
+  osMutexId mutex_;
+  uint32_t voltage_;  // millivolts
 } BatteryVoltageData;
 
 /* GPS Data */
 
 #define NMEA_MAX_LENGTH 82
 
-typedef struct
-{
-    int32_t    degrees_;
-    int32_t    minutes_;
+typedef struct {
+  int32_t degrees_;
+  int32_t minutes_;
 } LatLongType;
 
-typedef struct
-{
-    int32_t     altitude_;
-    char        unit_;
+typedef struct {
+  int32_t altitude_;
+  char unit_;
 } AltitudeType;
 
-typedef struct
-{
-    osMutexId       mutex_;
-    char            buffer_ [NMEA_MAX_LENGTH + 1];
-    uint32_t        time_;
-    LatLongType     latitude_;
-    LatLongType     longitude_;
-    AltitudeType    antennaAltitude_;
-    AltitudeType    geoidAltitude_;
-    AltitudeType    totalAltitude_;
-    uint8_t         parseFlag_;
+typedef struct {
+  osMutexId mutex_;
+  char buffer_[NMEA_MAX_LENGTH + 1];
+  uint32_t time_;
+  LatLongType latitude_;
+  LatLongType longitude_;
+  AltitudeType antennaAltitude_;
+  AltitudeType geoidAltitude_;
+  AltitudeType totalAltitude_;
+  uint8_t parseFlag_;
 } GpsData;
 
-typedef struct
-{
-    osMutexId   mutex_;
-    int32_t     pressure_;
+typedef struct {
+  osMutexId mutex_;
+  int32_t pressure_;
 } OxidizerTankPressureData;
 
 /* Data Containers */
@@ -85,48 +80,45 @@ typedef struct
  * This is meant to act as a pointer to the other data structs.
  */
 
-typedef struct
-{
-    AccelGyroMagnetismData*         accelGyroMagnetismData_;
-    BarometerData*                  barometerData_;
-    CombustionChamberPressureData*  combustionChamberPressureData_;
-    BatteryVoltageData*             batteryVoltageData_;
-    GpsData*                        gpsData_;
-    OxidizerTankPressureData*       oxidizerTankPressureData_;
+typedef struct {
+  AccelGyroMagnetismData* accelGyroMagnetismData_;
+  BarometerData* barometerData_;
+  CombustionChamberPressureData* combustionChamberPressureData_;
+  BatteryVoltageData* batteryVoltageData_;
+  GpsData* gpsData_;
+  OxidizerTankPressureData* oxidizerTankPressureData_;
 } AllData;
 
-typedef struct
-{
-    AccelGyroMagnetismData* accelGyroMagnetismData_;
-    BarometerData*          barometerData_;
+typedef struct {
+  AccelGyroMagnetismData* accelGyroMagnetismData_;
+  BarometerData* barometerData_;
 } ParachutesControlData;
 
-
 /* Structs -------------------------------------------------------------------*/
-typedef struct{
-    int32_t accelX;
-    int32_t accelY;
-    int32_t accelZ;
-    int32_t gyroX;
-    int32_t gyroY;
-    int32_t gyroZ;
-    int32_t magnetoX;
-    int32_t magnetoY;
-    int32_t magnetoZ;
-    int32_t barometerPressure;
-    int32_t barometerTemperature;
-    int32_t combustionChamberPressure;
-    int32_t oxidizerTankPressure;
-    int32_t gps_time;
-    int32_t latitude_degrees;
-    int32_t latitude_minutes;
-    int32_t longitude_degrees;
-    int32_t longitude_minutes;
-    int32_t antennaAltitude;
-    int32_t geoidAltitude;
-    int32_t altitude;
-    uint32_t batteryVoltage;
-    uint8_t currentFlightPhase;
-    int32_t tick;
+typedef struct {
+  int32_t accelX;
+  int32_t accelY;
+  int32_t accelZ;
+  int32_t gyroX;
+  int32_t gyroY;
+  int32_t gyroZ;
+  int32_t magnetoX;
+  int32_t magnetoY;
+  int32_t magnetoZ;
+  int32_t barometerPressure;
+  int32_t barometerTemperature;
+  int32_t combustionChamberPressure;
+  int32_t oxidizerTankPressure;
+  int32_t gps_time;
+  int32_t latitude_degrees;
+  int32_t latitude_minutes;
+  int32_t longitude_degrees;
+  int32_t longitude_minutes;
+  int32_t antennaAltitude;
+  int32_t geoidAltitude;
+  int32_t altitude;
+  uint32_t batteryVoltage;
+  uint8_t currentFlightPhase;
+  int32_t tick;
 
-} LogEntry; // LogEntry holds data from AllData that is to be logged
+} LogEntry;  // LogEntry holds data from AllData that is to be logged

--- a/Core/Inc/EngineControl.h
+++ b/Core/Inc/EngineControl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "main.h"
+
 extern UART_HandleTypeDef huart1;
 extern uint8_t launchCmdReceived;
 extern uint8_t systemIsArmed;

--- a/Core/Inc/FlightPhase.h
+++ b/Core/Inc/FlightPhase.h
@@ -1,33 +1,28 @@
 #pragma once
 
-#include "stm32f4xx_hal.h"
 #include "cmsis_os.h"
+#include "stm32f4xx_hal.h"
 
-#define IS_ABORT_PHASE ( \
-            getCurrentFlightPhase() == ABORT_COMMAND_RECEIVED || \
-            getCurrentFlightPhase() == ABORT_COMMUNICATION_ERROR || \
-            getCurrentFlightPhase() == ABORT_OXIDIZER_PRESSURE || \
-            getCurrentFlightPhase() == ABORT_UNSPECIFIED_REASON \
-        )
+#define IS_ABORT_PHASE                                                                                          \
+  (getCurrentFlightPhase() == ABORT_COMMAND_RECEIVED || getCurrentFlightPhase() == ABORT_COMMUNICATION_ERROR || \
+   getCurrentFlightPhase() == ABORT_OXIDIZER_PRESSURE || getCurrentFlightPhase() == ABORT_UNSPECIFIED_REASON)
 
-extern osMutexId flightPhaseMutex; // ONLY PUBLIC FOR INITIALIZATION PURPOSES
+extern osMutexId flightPhaseMutex;  // ONLY PUBLIC FOR INITIALIZATION PURPOSES
 
-typedef enum
-{
-    PRELAUNCH,
-    ARM,
-    BURN,
-    COAST,
-    DROGUE_DESCENT,
-    MAIN_DESCENT,
-    POST_FLIGHT,
-    ABORT_COMMAND_RECEIVED,
-    ABORT_COMMUNICATION_ERROR,
-    ABORT_OXIDIZER_PRESSURE,
-    ABORT_UNSPECIFIED_REASON
+typedef enum {
+  PRELAUNCH,
+  ARM,
+  BURN,
+  COAST,
+  DROGUE_DESCENT,
+  MAIN_DESCENT,
+  POST_FLIGHT,
+  ABORT_COMMAND_RECEIVED,
+  ABORT_COMMUNICATION_ERROR,
+  ABORT_OXIDIZER_PRESSURE,
+  ABORT_UNSPECIFIED_REASON
 } FlightPhase;
 
 void newFlightPhase(FlightPhase newPhase);
 FlightPhase getCurrentFlightPhase();
 void resetFlightPhase();
-

--- a/Core/Inc/LogData.h
+++ b/Core/Inc/LogData.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "main.h"
-#include "Data.h"
 #include "../../Drivers/w25qxx/w25qxx.h"
+#include "Data.h"
+#include "main.h"
 
 extern UART_HandleTypeDef huart5;
 extern SPI_HandleTypeDef hspi2;

--- a/Core/Inc/MonitorForEmergencyShutoff.h
+++ b/Core/Inc/MonitorForEmergencyShutoff.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 extern uint8_t abortCmdReceived;
 const extern int32_t HEARTBEAT_TIMEOUT;
 extern int32_t heartbeatTimer;

--- a/Core/Inc/ReadBarometer.h
+++ b/Core/Inc/ReadBarometer.h
@@ -5,4 +5,3 @@
 extern SPI_HandleTypeDef hspi3;
 
 void readBarometerTask(void const* arg);
-

--- a/Core/Inc/ReadBatteryVoltage.h
+++ b/Core/Inc/ReadBatteryVoltage.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "main.h"
+
 extern ADC_HandleTypeDef hadc2;
 
 void readBatteryVoltageTask(void const* arg);

--- a/Core/Inc/ReadCombustionChamberPressure.h
+++ b/Core/Inc/ReadCombustionChamberPressure.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "main.h"
+
 extern ADC_HandleTypeDef hadc1;
 
 void readCombustionChamberPressureTask(void const* arg);

--- a/Core/Inc/ReadOxidizerTankPressure.h
+++ b/Core/Inc/ReadOxidizerTankPressure.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "main.h"
+
 extern ADC_HandleTypeDef hadc2;
 
 void readOxidizerTankPressureTask(void const* arg);

--- a/Core/Inc/TransmitData.h
+++ b/Core/Inc/TransmitData.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "main.h"
+
 void transmitDataTask(void const* arg);
 
 #define GS_CMD_SZ_B 5

--- a/Core/Inc/Utils.h
+++ b/Core/Inc/Utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 uint16_t averageArray(uint16_t array[], int size);
 void writeInt32ToArray(uint8_t* array, int startIndex, int32_t value);
 void readUInt32FromUInt8Array(uint8_t* array, int startIndex, int32_t* value);

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -1,22 +1,22 @@
 /* USER CODE BEGIN Header */
 /**
-  ******************************************************************************
-  * @file           : main.h
-  * @brief          : Header for main.c file.
-  *                   This file contains the common defines of the application.
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2022 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under Ultimate Liberty license
-  * SLA0044, the "License"; You may not use this file except in compliance with
-  * the License. You may obtain a copy of the License at:
-  *                             www.st.com/SLA0044
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file           : main.h
+ * @brief          : Header for main.c file.
+ *                   This file contains the common defines of the application.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2022 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under Ultimate Liberty license
+ * SLA0044, the "License"; You may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at:
+ *                             www.st.com/SLA0044
+ *
+ ******************************************************************************
+ */
 /* USER CODE END Header */
 
 /* Define to prevent recursive inclusion -------------------------------------*/

--- a/Core/Src/AbortPhase.c
+++ b/Core/Src/AbortPhase.c
@@ -1,41 +1,35 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
 #include "AbortPhase.h"
+
 #include "FlightPhase.h"
 #include "ValveControl.h"
+#include "cmsis_os.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
 
 static const int ABORT_PHASE_TASK_PERIOD = 100;
 
-void abortPhaseTask(void const* arg)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
+void abortPhaseTask(void const* arg) {
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, ABORT_PHASE_TASK_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, ABORT_PHASE_TASK_PERIOD);
 
-        if (!IS_ABORT_PHASE)
-        {
-            // Do nothing if not in abort
-            resetAvionicsCmdReceived = 0;
-        }
-        else
-        {
-            openLowerVentValve();
+    if (!IS_ABORT_PHASE) {
+      // Do nothing if not in abort
+      resetAvionicsCmdReceived = 0;
+    } else {
+      openLowerVentValve();
 
-            // Detect a reset
-            if (resetAvionicsCmdReceived)
-            {
-                // Reset global variables
-                closeLowerVentValve();
-                launchCmdReceived = 0;
-                abortCmdReceived = 0;
-                resetAvionicsCmdReceived = 0;
-                heartbeatTimer = HEARTBEAT_TIMEOUT;
-                resetFlightPhase();
-            }
-        }
+      // Detect a reset
+      if (resetAvionicsCmdReceived) {
+        // Reset global variables
+        closeLowerVentValve();
+        launchCmdReceived = 0;
+        abortCmdReceived = 0;
+        resetAvionicsCmdReceived = 0;
+        heartbeatTimer = HEARTBEAT_TIMEOUT;
+        resetFlightPhase();
+      }
     }
+  }
 }

--- a/Core/Src/Debug.c
+++ b/Core/Src/Debug.c
@@ -1,21 +1,21 @@
 /**
-  ******************************************************************************
-  * File Name          : Debug.c
-  * Description        : Utilities for debugging the flight board.
-  ******************************************************************************
-*/
+ ******************************************************************************
+ * File Name          : Debug.c
+ * Description        : Utilities for debugging the flight board.
+ ******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
+#include "Debug.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "LogData.h"
+#include "cmsis_os.h"
+#include "main.h"
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "Debug.h"
-#include "LogData.h"
-#include "main.h"
-
-#include <string.h>
-#include <stdlib.h>
 
 /* Macros --------------------------------------------------------------------*/
 
@@ -25,7 +25,7 @@
 static const int DEBUG_TASK_PERIOD = 100;
 
 /* Variables -----------------------------------------------------------------*/
-uint8_t debugMsg[DEBUG_RX_BUFFER_SZ_B + 1]; // Ensure last byte always 0
+uint8_t debugMsg[DEBUG_RX_BUFFER_SZ_B + 1];  // Ensure last byte always 0
 uint8_t debugMsgIdx = 0;
 uint8_t isDebugMsgReady = 0;
 
@@ -68,7 +68,7 @@ void debugTask(void const* arg) {
     } else {
       switch (debugMsg[0]) {
         case 'p':
-          asm volatile ("nop"); // Labels can't point to declarations?
+          asm volatile("nop");  // Labels can't point to declarations?
           uint32_t page_num = str2uint32(&debugMsg[1], DEBUG_RX_BUFFER_SZ_B - 1);
           if (page_num >= w25qxx.PageCount) {
             HAL_UART_Transmit(&huart5, "BAD INDEX\n", 10, 1000);
@@ -84,7 +84,7 @@ void debugTask(void const* arg) {
           break;
 
         case 's':
-          asm volatile ("nop"); // Labels can't point to declarations?
+          asm volatile("nop");  // Labels can't point to declarations?
           uint32_t sector_num = str2uint32(&debugMsg[1], DEBUG_RX_BUFFER_SZ_B - 1);
           if (sector_num >= w25qxx.SectorCount) {
             HAL_UART_Transmit(&huart5, "BAD INDEX\n", 10, 1000);
@@ -100,7 +100,7 @@ void debugTask(void const* arg) {
           break;
 
         case 'b':
-          asm volatile ("nop"); // Labels can't point to declarations?
+          asm volatile("nop");  // Labels can't point to declarations?
           uint32_t block_num = str2uint32(&debugMsg[1], DEBUG_RX_BUFFER_SZ_B - 1);
           if (block_num >= w25qxx.BlockCount) {
             HAL_UART_Transmit(&huart5, "BAD INDEX\n", 10, 1000);

--- a/Core/Src/EngineControl.c
+++ b/Core/Src/EngineControl.c
@@ -1,59 +1,55 @@
+#include "EngineControl.h"
+
+#include "Data.h"
+#include "FlightPhase.h"
+#include "ValveControl.h"
+#include "cmsis_os.h"
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "EngineControl.h"
-#include "FlightPhase.h"
-#include "Data.h"
-#include "ValveControl.h"
 
 static const int PRELAUNCH_PHASE_PERIOD = 50;
 static const int BURN_DURATION = 5550;
 static const int POST_BURN_PERIOD = 1000;
 
-static const int POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION = 10 * 60 * 1000; // 10 minutes
+static const int POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION = 10 * 60 * 1000;  // 10 minutes
 
 /**
  * This routine keeps the injection valve closed during prelaunch.
  * This routine exits when the current flight phase is no longer PRELAUNCH.
  */
-void engineControlPrelaunchRoutine(OxidizerTankPressureData* data)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
+void engineControlPrelaunchRoutine(OxidizerTankPressureData* data) {
+  uint32_t prevWakeTime = osKernelSysTick();
+
+  closeInjectionValve();
+
+  for (;;) {
+    osDelayUntil(&prevWakeTime, PRELAUNCH_PHASE_PERIOD);
 
     closeInjectionValve();
+    closeLowerVentValve();
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, PRELAUNCH_PHASE_PERIOD);
+    int32_t oxidizerTankPressure = -1;
 
-        closeInjectionValve();
-        closeLowerVentValve();
+    // if (osMutexWait(data->mutex_, 0) == osOK)
+    // {
+    //     // read tank pressure
+    //     oxidizerTankPressure = data->pressure_;
+    //     osMutexRelease(data->mutex_);
 
-        int32_t oxidizerTankPressure = -1;
+    //     if (oxidizerTankPressure >= 850 * 1000)
+    //     {
+    //         newFlightPhase(ABORT_OXIDIZER_PRESSURE);
+    //     }
+    // }
 
-        // if (osMutexWait(data->mutex_, 0) == osOK)
-        // {
-        //     // read tank pressure
-        //     oxidizerTankPressure = data->pressure_;
-        //     osMutexRelease(data->mutex_);
-
-        //     if (oxidizerTankPressure >= 850 * 1000)
-        //     {
-        //         newFlightPhase(ABORT_OXIDIZER_PRESSURE);
-        //     }
-        // }
-
-        if (launchCmdReceived >= 2 && ARM == getCurrentFlightPhase())
-        {
-            newFlightPhase(BURN);
-        }
-
-        if (PRELAUNCH != getCurrentFlightPhase() && ARM != getCurrentFlightPhase())
-        {
-            return;
-        }
+    if (launchCmdReceived >= 2 && ARM == getCurrentFlightPhase()) {
+      newFlightPhase(BURN);
     }
+
+    if (PRELAUNCH != getCurrentFlightPhase() && ARM != getCurrentFlightPhase()) {
+      return;
+    }
+  }
 }
 
 /**
@@ -61,112 +57,99 @@ void engineControlPrelaunchRoutine(OxidizerTankPressureData* data)
  * for a preconfigured amount of time. Once the preconfigured amount
  * of time has passed, this routine updates the current flight phase.
  */
-void engineControlBurnRoutine()
-{
-    closeLowerVentValve();
-    openInjectionValve();
-    osDelay(BURN_DURATION);
-    newFlightPhase(COAST);
-    return;
+void engineControlBurnRoutine() {
+  closeLowerVentValve();
+  openInjectionValve();
+  osDelay(BURN_DURATION);
+  newFlightPhase(COAST);
+  return;
 }
 
 /**
  * This routine closes all valves and changes to the PostFlightRoutine
  * after 10 mins passed since COAST started.
  */
-void engineControlPostBurnRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t timeInPostBurn = 0;
+void engineControlPostBurnRoutine() {
+  uint32_t prevWakeTime = osKernelSysTick();
+  uint32_t timeInPostBurn = 0;
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
-        FlightPhase phase = getCurrentFlightPhase();
+  for (;;) {
+    osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
+    FlightPhase phase = getCurrentFlightPhase();
 
-        if (phase != COAST && phase != DROGUE_DESCENT && phase != MAIN_DESCENT)
-        {
-            return;
-        }
-
-        // requires 49 days to overflow, not handling this case
-        timeInPostBurn += POST_BURN_PERIOD;
-
-        if (timeInPostBurn < POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION)
-        {
-            closeInjectionValve();
-            closeLowerVentValve();
-        }
-        else
-        {
-            newFlightPhase(POST_FLIGHT);
-        }
+    if (phase != COAST && phase != DROGUE_DESCENT && phase != MAIN_DESCENT) {
+      return;
     }
+
+    // requires 49 days to overflow, not handling this case
+    timeInPostBurn += POST_BURN_PERIOD;
+
+    if (timeInPostBurn < POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION) {
+      closeInjectionValve();
+      closeLowerVentValve();
+    } else {
+      newFlightPhase(POST_FLIGHT);
+    }
+  }
 }
 
 /**
  * This routine is the final phase.
  */
-void engineControlPostFlightRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t timeInPostBurn = 0;
+void engineControlPostFlightRoutine() {
+  uint32_t prevWakeTime = osKernelSysTick();
+  uint32_t timeInPostBurn = 0;
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
-        FlightPhase phase = getCurrentFlightPhase();
+  for (;;) {
+    osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
+    FlightPhase phase = getCurrentFlightPhase();
 
-        if (phase != POST_FLIGHT)
-        {
-            return;
-        }
-
-        closeInjectionValve();
-        openLowerVentValve();
+    if (phase != POST_FLIGHT) {
+      return;
     }
+
+    closeInjectionValve();
+    openLowerVentValve();
+  }
 }
 
-void engineControlTask(void const* arg)
-{
-    OxidizerTankPressureData* data = (OxidizerTankPressureData*) arg;
+void engineControlTask(void const* arg) {
+  OxidizerTankPressureData* data = (OxidizerTankPressureData*)arg;
 
-    for (;;)
-    {
-        switch (getCurrentFlightPhase())
-        {
-            case PRELAUNCH:
-            case ARM:
-                engineControlPrelaunchRoutine(data);
-                break;
+  for (;;) {
+    switch (getCurrentFlightPhase()) {
+      case PRELAUNCH:
+      case ARM:
+        engineControlPrelaunchRoutine(data);
+        break;
 
-            case BURN:
-                engineControlBurnRoutine();
-                break;
+      case BURN:
+        engineControlBurnRoutine();
+        break;
 
-            case COAST:  // fall through
-            case DROGUE_DESCENT:
-            case MAIN_DESCENT:
-                engineControlPostBurnRoutine();
-                break;
+      case COAST:  // fall through
+      case DROGUE_DESCENT:
+      case MAIN_DESCENT:
+        engineControlPostBurnRoutine();
+        break;
 
-            case POST_FLIGHT:
-                engineControlPostFlightRoutine();
-                break;
+      case POST_FLIGHT:
+        engineControlPostFlightRoutine();
+        break;
 
-            // All aborts fall through here because they all do the same thing in each case
-            case ABORT_COMMAND_RECEIVED:
-            case ABORT_OXIDIZER_PRESSURE:
-            case ABORT_UNSPECIFIED_REASON:
-            case ABORT_COMMUNICATION_ERROR:
+      // All aborts fall through here because they all do the same thing in each case
+      case ABORT_COMMAND_RECEIVED:
+      case ABORT_OXIDIZER_PRESSURE:
+      case ABORT_UNSPECIFIED_REASON:
+      case ABORT_COMMUNICATION_ERROR:
 
-                // Do nothing and let other code do what needs to be done
-                osDelay(PRELAUNCH_PHASE_PERIOD);
+        // Do nothing and let other code do what needs to be done
+        osDelay(PRELAUNCH_PHASE_PERIOD);
 
-                break;
+        break;
 
-            default:
-                break;
-        }
+      default:
+        break;
     }
+  }
 }

--- a/Core/Src/FlightPhase.c
+++ b/Core/Src/FlightPhase.c
@@ -4,69 +4,58 @@ static FlightPhase currentFlightPhase = PRELAUNCH;
 
 static const int FLIGHT_MUTEX_RETRIES = 10;
 
-void newFlightPhase(FlightPhase newPhase)
-{
-    if (newPhase <= getCurrentFlightPhase())
-    {
-        return;
-    }
-
-    for (int i = 0; i < FLIGHT_MUTEX_RETRIES; i++)
-    {
-        if (osMutexWait(flightPhaseMutex, 0) == osOK)
-        {
-            if (newPhase > currentFlightPhase)
-            {
-                currentFlightPhase = newPhase;
-            }
-
-            osMutexRelease(flightPhaseMutex);
-            return;
-        }
-    }
-
-    // Hopefully it never gets here
-    // if it does, risk a race condition
-    // better than not setting the phase
-    currentFlightPhase = newPhase;
+void newFlightPhase(FlightPhase newPhase) {
+  if (newPhase <= getCurrentFlightPhase()) {
     return;
+  }
+
+  for (int i = 0; i < FLIGHT_MUTEX_RETRIES; i++) {
+    if (osMutexWait(flightPhaseMutex, 0) == osOK) {
+      if (newPhase > currentFlightPhase) {
+        currentFlightPhase = newPhase;
+      }
+
+      osMutexRelease(flightPhaseMutex);
+      return;
+    }
+  }
+
+  // Hopefully it never gets here
+  // if it does, risk a race condition
+  // better than not setting the phase
+  currentFlightPhase = newPhase;
+  return;
 }
 
-FlightPhase getCurrentFlightPhase()
-{
-    FlightPhase phase;
+FlightPhase getCurrentFlightPhase() {
+  FlightPhase phase;
 
-    for (int i = 0; i < FLIGHT_MUTEX_RETRIES; i++)
-    {
-        if (osMutexWait(flightPhaseMutex, 0) == osOK)
-        {
-            phase = currentFlightPhase;
-            osMutexRelease(flightPhaseMutex);
-            return phase;
-        }
+  for (int i = 0; i < FLIGHT_MUTEX_RETRIES; i++) {
+    if (osMutexWait(flightPhaseMutex, 0) == osOK) {
+      phase = currentFlightPhase;
+      osMutexRelease(flightPhaseMutex);
+      return phase;
     }
+  }
 
-    // Hopefully it never gets here
-    // if it does, risk a race condition
-    // better than returning invalid phase
-    return currentFlightPhase;
+  // Hopefully it never gets here
+  // if it does, risk a race condition
+  // better than returning invalid phase
+  return currentFlightPhase;
 }
 
-void resetFlightPhase()
-{
-    for (int i = 0; i < FLIGHT_MUTEX_RETRIES; i++)
-    {
-        if (osMutexWait(flightPhaseMutex, 0) == osOK)
-        {
-            currentFlightPhase = PRELAUNCH;
-            osMutexRelease(flightPhaseMutex);
-            return;
-        }
+void resetFlightPhase() {
+  for (int i = 0; i < FLIGHT_MUTEX_RETRIES; i++) {
+    if (osMutexWait(flightPhaseMutex, 0) == osOK) {
+      currentFlightPhase = PRELAUNCH;
+      osMutexRelease(flightPhaseMutex);
+      return;
     }
+  }
 
-    // Hopefully it never gets here
-    // if it does, risk a race condition
-    // better than not setting the phase
-    currentFlightPhase = PRELAUNCH;
-    return;
+  // Hopefully it never gets here
+  // if it does, risk a race condition
+  // better than not setting the phase
+  currentFlightPhase = PRELAUNCH;
+  return;
 }

--- a/Core/Src/LogData.c
+++ b/Core/Src/LogData.c
@@ -3,33 +3,37 @@
  * File Name          : LogData.c
  * Description        : Code handles logging of AllData for different routines
  ******************************************************************************
-*/
+ */
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
 #include "LogData.h"
-#include "FlightPhase.h"
-#include "Utils.h"
+
 #include <string.h>
 
+#include "FlightPhase.h"
+#include "Utils.h"
+#include "cmsis_os.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
+
 /* Macros --------------------------------------------------------------------*/
-#define max(a,b) \
-    ({ __typeof__ (a) _a = (a); \
-        __typeof__ (b) _b = (b); \
-        _a > _b ? _a : _b; })
+#define max(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a > _b ? _a : _b;      \
+  })
 
-#define min(a,b) \
-    ({ __typeof__ (a) _a = (a); \
-        __typeof__ (b) _b = (b); \
-        _a < _b ? _a : _b; })
-
+#define min(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a < _b ? _a : _b;      \
+  })
 
 /* Constants -----------------------------------------------------------------*/
-static const int32_t SLOW_LOG_DATA_PERIOD_ms = 200; // logging period for slow routine
-static const int32_t FAST_LOG_DATA_PERIOD_ms = 20; // logging period for fast routine
+static const int32_t SLOW_LOG_DATA_PERIOD_ms = 200;  // logging period for slow routine
+static const int32_t FAST_LOG_DATA_PERIOD_ms = 20;   // logging period for fast routine
 
 /* Variables -----------------------------------------------------------------*/
 uint8_t isOkayToLog;
@@ -37,19 +41,19 @@ uint8_t isErasing = 0;
 uint32_t currentSectorAddr = 0;
 uint32_t currentSectorOffset_B = 0;
 
-static uint16_t preFlightAddressOffset = 0; // offset updated after writing in logEntryOnceRoutine
-static uint16_t inFlightAddressOffset = 14*sizeof(LogEntry); // largest address to write to before flight, updated during flight
+static uint16_t preFlightAddressOffset = 0;  // offset updated after writing in logEntryOnceRoutine
+static uint16_t inFlightAddressOffset =
+    14 * sizeof(LogEntry);  // largest address to write to before flight, updated during flight
 
 /* Functions -----------------------------------------------------------------*/
 /**
  * @brief this method initializes the log entry struct
  * @param givenLog, pointer to a log created at the start of the task
  */
-void initializeLogEntry(LogEntry* givenLog)
-{
-	memset(givenLog, -1, sizeof(LogEntry));
-    givenLog->currentFlightPhase = getCurrentFlightPhase();
-    givenLog->tick = osKernelSysTick();
+void initializeLogEntry(LogEntry* givenLog) {
+  memset(givenLog, -1, sizeof(LogEntry));
+  givenLog->currentFlightPhase = getCurrentFlightPhase();
+  givenLog->tick = osKernelSysTick();
 }
 
 /**
@@ -57,62 +61,55 @@ void initializeLogEntry(LogEntry* givenLog)
  * @param data, pointer to AllData struct
  * @param givenLog, pointer to a log created at the start of the task
  */
-void updateLogEntry(AllData* data, LogEntry* givenLog)
-{
-    if (osMutexWait(data->accelGyroMagnetismData_->mutex_, 0) == osOK)
-    {
-        givenLog->accelX = data->accelGyroMagnetismData_->accelX_;
-        givenLog->accelY = data->accelGyroMagnetismData_->accelY_;
-        givenLog->accelZ = data->accelGyroMagnetismData_->accelZ_;
-        givenLog->gyroX = data->accelGyroMagnetismData_->gyroX_;
-        givenLog->gyroY = data->accelGyroMagnetismData_->gyroY_;
-        givenLog->gyroZ = data->accelGyroMagnetismData_->gyroZ_;
-        givenLog->magnetoX = data->accelGyroMagnetismData_->magnetoX_;
-        givenLog->magnetoY = data->accelGyroMagnetismData_->magnetoY_;
-        givenLog->magnetoZ = data->accelGyroMagnetismData_->magnetoZ_;
-        osMutexRelease(data->accelGyroMagnetismData_->mutex_);
-    }
+void updateLogEntry(AllData* data, LogEntry* givenLog) {
+  if (osMutexWait(data->accelGyroMagnetismData_->mutex_, 0) == osOK) {
+    givenLog->accelX = data->accelGyroMagnetismData_->accelX_;
+    givenLog->accelY = data->accelGyroMagnetismData_->accelY_;
+    givenLog->accelZ = data->accelGyroMagnetismData_->accelZ_;
+    givenLog->gyroX = data->accelGyroMagnetismData_->gyroX_;
+    givenLog->gyroY = data->accelGyroMagnetismData_->gyroY_;
+    givenLog->gyroZ = data->accelGyroMagnetismData_->gyroZ_;
+    givenLog->magnetoX = data->accelGyroMagnetismData_->magnetoX_;
+    givenLog->magnetoY = data->accelGyroMagnetismData_->magnetoY_;
+    givenLog->magnetoZ = data->accelGyroMagnetismData_->magnetoZ_;
+    osMutexRelease(data->accelGyroMagnetismData_->mutex_);
+  }
 
-    if (osMutexWait(data->barometerData_->mutex_, 0) == osOK)
-    {
-        givenLog->barometerPressure = data->barometerData_->pressure_;
-        givenLog->barometerTemperature = data->barometerData_->temperature_;
-        osMutexRelease(data->barometerData_->mutex_);
-    }
+  if (osMutexWait(data->barometerData_->mutex_, 0) == osOK) {
+    givenLog->barometerPressure = data->barometerData_->pressure_;
+    givenLog->barometerTemperature = data->barometerData_->temperature_;
+    osMutexRelease(data->barometerData_->mutex_);
+  }
 
-    if (osMutexWait(data->combustionChamberPressureData_->mutex_, 0) == osOK)
-    {
-        givenLog->combustionChamberPressure = data->combustionChamberPressureData_->pressure_;
-        osMutexRelease(data->combustionChamberPressureData_->mutex_);
-    }
+  if (osMutexWait(data->combustionChamberPressureData_->mutex_, 0) == osOK) {
+    givenLog->combustionChamberPressure = data->combustionChamberPressureData_->pressure_;
+    osMutexRelease(data->combustionChamberPressureData_->mutex_);
+  }
 
-     if (osMutexWait(data->oxidizerTankPressureData_->mutex_, 0) == osOK)
-    {
-        givenLog->oxidizerTankPressure = data->oxidizerTankPressureData_->pressure_;
-        osMutexRelease(data->oxidizerTankPressureData_->mutex_);
-    }
+  if (osMutexWait(data->oxidizerTankPressureData_->mutex_, 0) == osOK) {
+    givenLog->oxidizerTankPressure = data->oxidizerTankPressureData_->pressure_;
+    osMutexRelease(data->oxidizerTankPressureData_->mutex_);
+  }
 
-    if (osMutexWait(data->gpsData_->mutex_, 0) == osOK)
-    {
-        givenLog->gps_time = data->gpsData_->time_;
-        givenLog->latitude_degrees = data->gpsData_->latitude_.degrees_;
-        givenLog->latitude_minutes = data->gpsData_->latitude_.minutes_;
-        givenLog->longitude_degrees = data->gpsData_->longitude_.degrees_;
-        givenLog->longitude_minutes = data->gpsData_->longitude_.minutes_;
-        givenLog->antennaAltitude = data->gpsData_->antennaAltitude_.altitude_;
-        givenLog->geoidAltitude = data->gpsData_->geoidAltitude_.altitude_;
-        givenLog->altitude = data->gpsData_->totalAltitude_.altitude_;
-        osMutexRelease(data->gpsData_->mutex_);
-    }
+  if (osMutexWait(data->gpsData_->mutex_, 0) == osOK) {
+    givenLog->gps_time = data->gpsData_->time_;
+    givenLog->latitude_degrees = data->gpsData_->latitude_.degrees_;
+    givenLog->latitude_minutes = data->gpsData_->latitude_.minutes_;
+    givenLog->longitude_degrees = data->gpsData_->longitude_.degrees_;
+    givenLog->longitude_minutes = data->gpsData_->longitude_.minutes_;
+    givenLog->antennaAltitude = data->gpsData_->antennaAltitude_.altitude_;
+    givenLog->geoidAltitude = data->gpsData_->geoidAltitude_.altitude_;
+    givenLog->altitude = data->gpsData_->totalAltitude_.altitude_;
+    osMutexRelease(data->gpsData_->mutex_);
+  }
 
-    if (osMutexWait(data->batteryVoltageData_->mutex_, 0) == osOK)
-    {
-        givenLog->batteryVoltage = data->batteryVoltageData_->voltage_;
-        osMutexRelease(data->batteryVoltageData_->mutex_);
-    }
-    
-    givenLog->currentFlightPhase = getCurrentFlightPhase();
-    givenLog->tick = HAL_GetTick();
+  if (osMutexWait(data->batteryVoltageData_->mutex_, 0) == osOK) {
+    givenLog->batteryVoltage = data->batteryVoltageData_->voltage_;
+    osMutexRelease(data->batteryVoltageData_->mutex_);
+  }
+
+  givenLog->currentFlightPhase = getCurrentFlightPhase();
+  givenLog->tick = HAL_GetTick();
 }
 
 /**
@@ -122,98 +119,93 @@ void updateLogEntry(AllData* data, LogEntry* givenLog)
  * @param logStartAddress, pointer to the start of memory for flight logging
  * @return True if the log was written, false otherwise
  */
-bool logEntryOnceRoutine(AllData* data, LogEntry* givenLog, uint16_t* logStartAddress)
-{
-    if (!isOkayToLog || isErasing) {
-        return false;
+bool logEntryOnceRoutine(AllData* data, LogEntry* givenLog, uint16_t* logStartAddress) {
+  if (!isOkayToLog || isErasing) {
+    return false;
+  }
+
+  updateLogEntry(data, givenLog);
+
+  /*
+   * Loop over sectors in order to log a contiguous section of data across as many sectors as needed.
+   * For each loop, determine which is smaller: THe bytes free in the current sector, or the number
+   * of bytes in the log left to log. Take this smaller value, and write that many bytes to the current
+   * sector. If you're at the end of the current sector, transfer to the next sector. Repeat until
+   * the entire log is written!
+   */
+
+  uint8_t* logPtr = (uint8_t*)(givenLog);
+  uint32_t internalLogOffset = 0;
+  uint32_t numBytesLeftInLog = sizeof(LogEntry);
+  while (numBytesLeftInLog > 0) {
+    if (currentSectorOffset_B >= w25qxx.SectorSize) {
+      // Current sector is full, move to the next sector
+      currentSectorOffset_B %= w25qxx.SectorSize;
+      currentSectorAddr += 1;
     }
 
-    updateLogEntry(data, givenLog);
-
-    /*
-     * Loop over sectors in order to log a contiguous section of data across as many sectors as needed.
-     * For each loop, determine which is smaller: THe bytes free in the current sector, or the number
-     * of bytes in the log left to log. Take this smaller value, and write that many bytes to the current
-     * sector. If you're at the end of the current sector, transfer to the next sector. Repeat until
-     * the entire log is written!
-     */
-
-    uint8_t* logPtr = (uint8_t*)(givenLog);
-    uint32_t internalLogOffset = 0;
-    uint32_t numBytesLeftInLog = sizeof(LogEntry);
-    while (numBytesLeftInLog > 0) {
-      if (currentSectorOffset_B >= w25qxx.SectorSize) {
-        // Current sector is full, move to the next sector
-        currentSectorOffset_B %= w25qxx.SectorSize;
-        currentSectorAddr += 1;
-      }
-
-      if (currentSectorAddr >= w25qxx.SectorCount) {
-        // Chip is full, can't log anymore!
-        HAL_GPIO_WritePin(LED_3_GPIO_Port, LED_3_Pin, 1);
-        return false;
-      }
-
-      HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 1);
-
-      // Write next portion of log into current flash sector,
-      // # free bytes in sector or rest of the log, whichever is lowest.
-      uint32_t numFreeBytesInSector = w25qxx.SectorSize - currentSectorOffset_B;
-      uint32_t numBytesToWrite = min(numFreeBytesInSector, numBytesLeftInLog) ;
-      W25qxx_WriteSector(&logPtr[internalLogOffset], currentSectorAddr, currentSectorOffset_B, numBytesToWrite);
-
-      currentSectorOffset_B += numBytesToWrite;
-      numBytesLeftInLog -= numBytesToWrite;
-      internalLogOffset += numBytesToWrite;
-
-      HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 0);
+    if (currentSectorAddr >= w25qxx.SectorCount) {
+      // Chip is full, can't log anymore!
+      HAL_GPIO_WritePin(LED_3_GPIO_Port, LED_3_Pin, 1);
+      return false;
     }
 
-    return true;
+    HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 1);
+
+    // Write next portion of log into current flash sector,
+    // # free bytes in sector or rest of the log, whichever is lowest.
+    uint32_t numFreeBytesInSector = w25qxx.SectorSize - currentSectorOffset_B;
+    uint32_t numBytesToWrite = min(numFreeBytesInSector, numBytesLeftInLog);
+    W25qxx_WriteSector(&logPtr[internalLogOffset], currentSectorAddr, currentSectorOffset_B, numBytesToWrite);
+
+    currentSectorOffset_B += numBytesToWrite;
+    numBytesLeftInLog -= numBytesToWrite;
+    internalLogOffset += numBytesToWrite;
+
+    HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 0);
+  }
+
+  return true;
 }
 
-void logDataTask(void const* arg)
-{
-    AllData* data = (AllData*) arg;
-    LogEntry log;
-    initializeLogEntry(&log);
-    uint32_t prevWakeTime, beforeLogTime;
-    isOkayToLog = HAL_GPIO_ReadPin(AUX_1_GPIO_Port, AUX_1_Pin); // Don't log in debug mode! Otherwise, log.
-    for (;;)
-    {
-      if (isErasing) {
-        HAL_UART_Transmit(&huart5, "ERASING\n", 8, 1000);
-        HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 1);
-        W25qxx_EraseChip();
-        HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 0);
-        isErasing = 0;
-        HAL_UART_Transmit(&huart5, "ERASED\n", 7, 1000);
-      }
-    	beforeLogTime = osKernelSysTick();
-        switch (getCurrentFlightPhase())
-        {
-        	case PRELAUNCH:
-        	case ARM:
-        		logEntryOnceRoutine(data, &log, &preFlightAddressOffset);
-        		if ((inFlightAddressOffset - preFlightAddressOffset) < sizeof(LogEntry))
-        			preFlightAddressOffset = 0;
-        		prevWakeTime = osKernelSysTick(); //assume it is atomic: runs in one cycle
-        		osDelayUntil(&prevWakeTime, (uint32_t)(max(SLOW_LOG_DATA_PERIOD_ms - (osKernelSysTick() - beforeLogTime), 0)));
-        		break;
-
-        	case BURN:
-        	case COAST:
-        	case DROGUE_DESCENT:
-        		logEntryOnceRoutine(data, &log, &inFlightAddressOffset);
-        		prevWakeTime = osKernelSysTick();
-        		osDelayUntil(&prevWakeTime, (uint32_t)(max(FAST_LOG_DATA_PERIOD_ms - (osKernelSysTick() - beforeLogTime), 0)));
-        		break;
-
-        	default:
-        		logEntryOnceRoutine(data, &log, &inFlightAddressOffset);
-        		prevWakeTime = osKernelSysTick();
-        		osDelayUntil(&prevWakeTime, (uint32_t)(max(SLOW_LOG_DATA_PERIOD_ms - (osKernelSysTick() - beforeLogTime), 0)));
-        		break;
-        }
+void logDataTask(void const* arg) {
+  AllData* data = (AllData*)arg;
+  LogEntry log;
+  initializeLogEntry(&log);
+  uint32_t prevWakeTime, beforeLogTime;
+  isOkayToLog = HAL_GPIO_ReadPin(AUX_1_GPIO_Port, AUX_1_Pin);  // Don't log in debug mode! Otherwise, log.
+  for (;;) {
+    if (isErasing) {
+      HAL_UART_Transmit(&huart5, "ERASING\n", 8, 1000);
+      HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 1);
+      W25qxx_EraseChip();
+      HAL_GPIO_WritePin(LED_2_GPIO_Port, LED_2_Pin, 0);
+      isErasing = 0;
+      HAL_UART_Transmit(&huart5, "ERASED\n", 7, 1000);
     }
+    beforeLogTime = osKernelSysTick();
+    switch (getCurrentFlightPhase()) {
+      case PRELAUNCH:
+      case ARM:
+        logEntryOnceRoutine(data, &log, &preFlightAddressOffset);
+        if ((inFlightAddressOffset - preFlightAddressOffset) < sizeof(LogEntry)) preFlightAddressOffset = 0;
+        prevWakeTime = osKernelSysTick();  // assume it is atomic: runs in one cycle
+        osDelayUntil(&prevWakeTime, (uint32_t)(max(SLOW_LOG_DATA_PERIOD_ms - (osKernelSysTick() - beforeLogTime), 0)));
+        break;
+
+      case BURN:
+      case COAST:
+      case DROGUE_DESCENT:
+        logEntryOnceRoutine(data, &log, &inFlightAddressOffset);
+        prevWakeTime = osKernelSysTick();
+        osDelayUntil(&prevWakeTime, (uint32_t)(max(FAST_LOG_DATA_PERIOD_ms - (osKernelSysTick() - beforeLogTime), 0)));
+        break;
+
+      default:
+        logEntryOnceRoutine(data, &log, &inFlightAddressOffset);
+        prevWakeTime = osKernelSysTick();
+        osDelayUntil(&prevWakeTime, (uint32_t)(max(SLOW_LOG_DATA_PERIOD_ms - (osKernelSysTick() - beforeLogTime), 0)));
+        break;
+    }
+  }
 }

--- a/Core/Src/MonitorForEmergencyShutoff.c
+++ b/Core/Src/MonitorForEmergencyShutoff.c
@@ -1,110 +1,98 @@
+#include "MonitorForEmergencyShutoff.h"
+
+#include "Data.h"
+#include "FlightPhase.h"
+#include "ValveControl.h"
+#include "cmsis_os.h"
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "MonitorForEmergencyShutoff.h"
-#include "FlightPhase.h"
-#include "Data.h"
-#include "ValveControl.h"
 
 static const int MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD = 1000;
 
-void monitorForEmergencyShutoffTask(void const* arg)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
+void monitorForEmergencyShutoffTask(void const* arg) {
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    // AccelGyroMagnetismData* data = (AccelGyroMagnetismData*) arg;
-    FlightPhase phase = PRELAUNCH;
-    // int32_t magnetoZ = -1;
+  // AccelGyroMagnetismData* data = (AccelGyroMagnetismData*) arg;
+  FlightPhase phase = PRELAUNCH;
+  // int32_t magnetoZ = -1;
 
-    heartbeatTimer = HEARTBEAT_TIMEOUT; // Timer counts down to 0
+  heartbeatTimer = HEARTBEAT_TIMEOUT;  // Timer counts down to 0
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD);
 
-        phase = getCurrentFlightPhase();
+    phase = getCurrentFlightPhase();
 
-        // if (osMutexWait(data->mutex_, 0) == osOK)
-        // {
-        //     magnetoZ = data->magnetoZ_;
-        //     osMutexRelease(data->mutex_);
-        // }
+    // if (osMutexWait(data->mutex_, 0) == osOK)
+    // {
+    //     magnetoZ = data->magnetoZ_;
+    //     osMutexRelease(data->mutex_);
+    // }
 
-        switch (getCurrentFlightPhase())
-        {
-            // Fallthrough because umbilical is still supposed to be connected during these flight phases.
-            // This means that an ABORT command can be received or a communication error could happen.
-            case PRELAUNCH:
-            case ARM:
-                heartbeatTimer -= MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD;
+    switch (getCurrentFlightPhase()) {
+      // Fallthrough because umbilical is still supposed to be connected during these flight phases.
+      // This means that an ABORT command can be received or a communication error could happen.
+      case PRELAUNCH:
+      case ARM:
+        heartbeatTimer -= MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD;
 
-                int prelaunchCheckStatus = prelaunchChecks();
+        int prelaunchCheckStatus = prelaunchChecks();
 
-                if (prelaunchCheckStatus == 1)
-                {
-                    newFlightPhase(ABORT_COMMAND_RECEIVED);
-                }
-                else if (prelaunchCheckStatus == 2)
-                {
-                    newFlightPhase(ABORT_COMMUNICATION_ERROR);
-                }
-
-                break;
-
-            // Fallthrough because the umbilical should be disconnected during these flight phases.
-            // This means that a communication error is not a valid way to get to ABORT. The only
-            // way the ABORT command can be received is if the rocket fails to take off and the
-            // umbilical does not disconnect.
-            case BURN:
-            case COAST:
-            case DROGUE_DESCENT:
-            case MAIN_DESCENT:
-            case POST_FLIGHT:
-                if (postArmChecks())
-                {
-                    newFlightPhase(ABORT_COMMAND_RECEIVED);
-                }
-
-                // check if not right side up
-                // if ()
-                // {
-                //     newFlightPhase(ABORT);
-                // }
-                break;
-
-            default:
-                // do nothing
-                break;
+        if (prelaunchCheckStatus == 1) {
+          newFlightPhase(ABORT_COMMAND_RECEIVED);
+        } else if (prelaunchCheckStatus == 2) {
+          newFlightPhase(ABORT_COMMUNICATION_ERROR);
         }
+
+        break;
+
+      // Fallthrough because the umbilical should be disconnected during these flight phases.
+      // This means that a communication error is not a valid way to get to ABORT. The only
+      // way the ABORT command can be received is if the rocket fails to take off and the
+      // umbilical does not disconnect.
+      case BURN:
+      case COAST:
+      case DROGUE_DESCENT:
+      case MAIN_DESCENT:
+      case POST_FLIGHT:
+        if (postArmChecks()) {
+          newFlightPhase(ABORT_COMMAND_RECEIVED);
+        }
+
+        // check if not right side up
+        // if ()
+        // {
+        //     newFlightPhase(ABORT);
+        // }
+        break;
+
+      default:
+        // do nothing
+        break;
     }
+  }
 }
 
 // Return 0 for everything ok
-int prelaunchChecks()
-{
-    if (abortCmdReceived)
-    {
-        return 1;
-    }
+int prelaunchChecks() {
+  if (abortCmdReceived) {
+    return 1;
+  }
 
-    // If heartbeatTimer reaches 0, no heartbeat was received for HEARTBEAT_TIMEOUT
-    if (heartbeatTimer <= 0)
-    {
-        return 2;
-    }
+  // If heartbeatTimer reaches 0, no heartbeat was received for HEARTBEAT_TIMEOUT
+  if (heartbeatTimer <= 0) {
+    return 2;
+  }
 
-    return 0;
+  return 0;
 }
 
 // Return 0 for everything ok
-int postArmChecks()
-{
-    if (abortCmdReceived)
-    {
-        closeInjectionValve();
-        return 1;
-    }
+int postArmChecks() {
+  if (abortCmdReceived) {
+    closeInjectionValve();
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }

--- a/Core/Src/ParachutesControl.c
+++ b/Core/Src/ParachutesControl.c
@@ -1,77 +1,61 @@
+#include "ParachutesControl.h"
+
 #include <math.h>
 
+#include "Data.h"
+#include "FlightPhase.h"
+#include "cmsis_os.h"
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
 
-#include "ParachutesControl.h"
-#include "FlightPhase.h"
-#include "Data.h"
-
-#define SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL (1401) // metres
+#define SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL (1401)  // metres
 
 // Pressure at spaceport america in 100*millibars on May 27, 2018
-static const int SEA_LEVEL_PRESSURE = 101421.93903699999; //TODO: THIS NEEDS TO BE UPDATED AND RECORDED ON LAUNCH DAY
+static const int SEA_LEVEL_PRESSURE = 101421.93903699999;  // TODO: THIS NEEDS TO BE UPDATED AND RECORDED ON LAUNCH DAY
 
 // Units in meters. Equivalent of 1500 ft + altitude of spaceport america.
 static const int MAIN_DEPLOYMENT_ALTITUDE = 457 + SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL;
 
 static const int MONITOR_FOR_PARACHUTES_PERIOD = 50;
-static const int KALMAN_FILTER_DROGUE_TIMEOUT = 2 * 60 * 1000; // 2 minutes
-static const int KALMAN_FILTER_MAIN_TIMEOUT = 10 * 60 * 1000; // 10 minutes
-static const int PARACHUTE_PULSE_DURATION = 2 * 1000; // 2 seconds
-static const double KALMAN_GAIN[][2] =
-{
-    {0.105553059, 0.109271566},
-    {0.0361533034, 0.0661198847},
-    {0.000273178915, 0.618030079}
-};
+static const int KALMAN_FILTER_DROGUE_TIMEOUT = 2 * 60 * 1000;  // 2 minutes
+static const int KALMAN_FILTER_MAIN_TIMEOUT = 10 * 60 * 1000;   // 10 minutes
+static const int PARACHUTE_PULSE_DURATION = 2 * 1000;           // 2 seconds
+static const double KALMAN_GAIN[][2] = {
+    {0.105553059, 0.109271566}, {0.0361533034, 0.0661198847}, {0.000273178915, 0.618030079}};
 
-struct KalmanStateVector
-{
-    double altitude;
-    double velocity;
-    double acceleration;
+struct KalmanStateVector {
+  double altitude;
+  double velocity;
+  double acceleration;
 };
 
 static struct KalmanStateVector kalmanFilterState;
 
-int32_t readAccel(AccelGyroMagnetismData* data)
-{
-    if (osMutexWait(data->mutex_, 0) != osOK)
-    {
-        return -1;
-    }
+int32_t readAccel(AccelGyroMagnetismData* data) {
+  if (osMutexWait(data->mutex_, 0) != osOK) {
+    return -1;
+  }
 
-    int32_t accelX = data->accelX_;
-    int32_t accelY = data->accelY_;
-    int32_t accelZ = data->accelZ_;
-    osMutexRelease(data->mutex_);
+  int32_t accelX = data->accelX_;
+  int32_t accelY = data->accelY_;
+  int32_t accelZ = data->accelZ_;
+  osMutexRelease(data->mutex_);
 
-    int32_t accelMagnitude =
-        sqrt(
-            accelX * accelX +
-            accelY * accelY +
-            accelZ * accelZ
-        );
+  int32_t accelMagnitude = sqrt(accelX * accelX + accelY * accelY + accelZ * accelZ);
 
-    return accelMagnitude;
+  return accelMagnitude;
 }
 
-int32_t readPressure(BarometerData* data)
-{
-    if (osMutexWait(data->mutex_, 0) != osOK)
-    {
-        return -1;
-    }
+int32_t readPressure(BarometerData* data) {
+  if (osMutexWait(data->mutex_, 0) != osOK) {
+    return -1;
+  }
 
-    int32_t pressure = data->pressure_;
-    osMutexRelease(data->mutex_);
+  int32_t pressure = data->pressure_;
+  osMutexRelease(data->mutex_);
 
-    return (int32_t)pressure;
+  return (int32_t)pressure;
 }
-
-
 
 /**
  * Takes an old state vector and current state measurements and
@@ -86,39 +70,33 @@ int32_t readPressure(BarometerData* data)
  * Returns:
  *   newState - (KalmanStateVector) Current altitude, velocity and acceleration
  */
-struct KalmanStateVector filterSensors(
-    struct KalmanStateVector oldState,
-    int32_t currentAccel,
-    int32_t currentPressure,
-    double dtMillis
-)
-{
-    struct KalmanStateVector newState;
+struct KalmanStateVector filterSensors(struct KalmanStateVector oldState, int32_t currentAccel, int32_t currentPressure,
+                                       double dtMillis) {
+  struct KalmanStateVector newState;
 
-    double accelIn = (double) currentAccel / 1000 * 9.8; // Milli-g -> g -> m/s
+  double accelIn = (double)currentAccel / 1000 * 9.8;  // Milli-g -> g -> m/s
 
-    // Convert from 100*millibars to m. This may or may not be right, depending on where you look. Needs testing
-    double altIn = (double) 44307.69396 * (1 - pow(currentPressure / SEA_LEVEL_PRESSURE, 0.190284));
+  // Convert from 100*millibars to m. This may or may not be right, depending on where you look. Needs testing
+  double altIn = (double)44307.69396 * (1 - pow(currentPressure / SEA_LEVEL_PRESSURE, 0.190284));
 
-    // Convert from ms to s
-    double dt = dtMillis / 1000;
+  // Convert from ms to s
+  double dt = dtMillis / 1000;
 
+  // Propagate old state using simple kinematics equations
+  newState.altitude = oldState.altitude + oldState.velocity * dt + 0.5 * dt * dt * oldState.acceleration;
+  newState.velocity = oldState.velocity + oldState.acceleration * dt;
+  newState.acceleration = oldState.acceleration;
 
-    // Propagate old state using simple kinematics equations
-    newState.altitude = oldState.altitude + oldState.velocity * dt + 0.5 * dt * dt * oldState.acceleration;
-    newState.velocity = oldState.velocity + oldState.acceleration * dt;
-    newState.acceleration = oldState.acceleration;
+  // Calculate the difference between the new state and the measurements
+  double baroDifference = altIn - newState.altitude;
+  double accelDifference = accelIn - newState.acceleration;
 
-    // Calculate the difference between the new state and the measurements
-    double baroDifference = altIn - newState.altitude;
-    double accelDifference = accelIn - newState.acceleration;
+  // Minimize the chi2 error by means of the Kalman gain matrix
+  newState.altitude = newState.altitude + KALMAN_GAIN[0][0] * baroDifference + KALMAN_GAIN[0][1] * accelDifference;
+  newState.velocity = newState.velocity + KALMAN_GAIN[1][0] * baroDifference + KALMAN_GAIN[1][1] * accelDifference;
+  newState.acceleration = newState.velocity + KALMAN_GAIN[2][0] * baroDifference + KALMAN_GAIN[2][1] * accelDifference;
 
-    // Minimize the chi2 error by means of the Kalman gain matrix
-    newState.altitude = newState.altitude + KALMAN_GAIN[0][0] * baroDifference + KALMAN_GAIN[0][1] * accelDifference;
-    newState.velocity = newState.velocity + KALMAN_GAIN[1][0] * baroDifference + KALMAN_GAIN[1][1] * accelDifference;
-    newState.acceleration = newState.velocity + KALMAN_GAIN[2][0] * baroDifference + KALMAN_GAIN[2][1] * accelDifference;
-
-    return newState;
+  return newState;
 }
 
 /**
@@ -130,15 +108,13 @@ struct KalmanStateVector filterSensors(
  * Returns:
  *   - (int32_t) 1 if apogee has been reached, 0 if not.
  */
-int32_t detectApogee(struct KalmanStateVector state)
-{
-    // Monitor for when to deploy drogue chute. Simple velocity tolerance, looking for a minimum.
-    if (state.velocity < 10)
-    {
-        return 1;
-    }
+int32_t detectApogee(struct KalmanStateVector state) {
+  // Monitor for when to deploy drogue chute. Simple velocity tolerance, looking for a minimum.
+  if (state.velocity < 10) {
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
 /**
@@ -153,124 +129,103 @@ int32_t detectApogee(struct KalmanStateVector state)
  * Returns:
  *   - (int32_t) 1 if main chute should be deployed, 0 if not.
  */
-int32_t detectMainDeploymentAltitude(struct KalmanStateVector state)
-{
-    // Monitor for when to deploy main chute. Simply look for less than desired altitude.
-    if (state.altitude < MAIN_DEPLOYMENT_ALTITUDE)
-    {
-        return 1;
-    }
+int32_t detectMainDeploymentAltitude(struct KalmanStateVector state) {
+  // Monitor for when to deploy main chute. Simply look for less than desired altitude.
+  if (state.altitude < MAIN_DEPLOYMENT_ALTITUDE) {
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
-//void ejectDrogueParachute()
+// void ejectDrogueParachute()
 //{
-//    HAL_GPIO_WritePin(DROGUE_PARACHUTE_TEMP_GPIO_Port, DROGUE_PARACHUTE_TEMP_Pin, GPIO_PIN_SET);  // high signal causes high current to ignite e-match
+//    HAL_GPIO_WritePin(DROGUE_PARACHUTE_TEMP_GPIO_Port, DROGUE_PARACHUTE_TEMP_Pin, GPIO_PIN_SET);  // high signal
+//    causes high current to ignite e-match
 //}
 //
-//void closeDrogueParachute()
+// void closeDrogueParachute()
 //{
 //    HAL_GPIO_WritePin(DROGUE_PARACHUTE_TEMP_GPIO_Port, DROGUE_PARACHUTE_TEMP_Pin, GPIO_PIN_RESET);
 //}
 
-void ejectMainParachute()
-{
-//    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_SET);  // high signal causes high current to ignite e-match
+void ejectMainParachute() {
+  //    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_SET);  // high signal causes high
+  //    current to ignite e-match
 }
 
-void closeMainParachute()
-{
-//    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_RESET);
+void closeMainParachute() {
+  //    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_RESET);
 }
-
 
 /**
  * This routine just waits for the current flight phase to get out of PRELAUNCH
  */
-void parachutesControlPrelaunchRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
+void parachutesControlPrelaunchRoutine() {
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
 
-        if (getCurrentFlightPhase() != PRELAUNCH)
-        {
-            // Ascent has begun
-            return;
-        }
+    if (getCurrentFlightPhase() != PRELAUNCH) {
+      // Ascent has begun
+      return;
     }
+  }
 }
 
-void parachutesControlBurnRoutine(
-    AccelGyroMagnetismData* accelGyroMagnetismData,
-    BarometerData* barometerData
-)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
+void parachutesControlBurnRoutine(AccelGyroMagnetismData* accelGyroMagnetismData, BarometerData* barometerData) {
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
 
-        if (getCurrentFlightPhase() != BURN)
-        {
-            return;
-        }
-
-        int32_t currentAccel = readAccel(accelGyroMagnetismData);
-        int32_t currentPressure = readPressure(barometerData);
-
-        if (currentAccel == -1 || currentPressure == -1)
-        {
-            // failed to read values
-            continue;
-        }
-
-        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
+    if (getCurrentFlightPhase() != BURN) {
+      return;
     }
-}
 
+    int32_t currentAccel = readAccel(accelGyroMagnetismData);
+    int32_t currentPressure = readPressure(barometerData);
+
+    if (currentAccel == -1 || currentPressure == -1) {
+      // failed to read values
+      continue;
+    }
+
+    filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
+  }
+}
 
 /**
  * This routine monitors for apogee.
  * Once apogee has been detected,
  * eject the drogue parachute and update the current flight phase.
  */
-void parachutesControlCoastRoutine(
-    AccelGyroMagnetismData* accelGyroMagnetismData,
-    BarometerData* barometerData
-)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t elapsedTime = 0;
+void parachutesControlCoastRoutine(AccelGyroMagnetismData* accelGyroMagnetismData, BarometerData* barometerData) {
+  uint32_t prevWakeTime = osKernelSysTick();
+  uint32_t elapsedTime = 0;
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
 
-        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
+    elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
 
-        int32_t currentAccel = readAccel(accelGyroMagnetismData);
-        int32_t currentPressure = readPressure(barometerData);
+    int32_t currentAccel = readAccel(accelGyroMagnetismData);
+    int32_t currentPressure = readPressure(barometerData);
 
-        if (currentAccel == -1 || currentPressure == -1)
-        {
-            // failed to read values
-            continue;
-        }
-
-        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        if (detectApogee(kalmanFilterState) || elapsedTime > KALMAN_FILTER_DROGUE_TIMEOUT)
-        {
-            //ejectDrogueParachute();
-            newFlightPhase(DROGUE_DESCENT);
-            return;
-        }
+    if (currentAccel == -1 || currentPressure == -1) {
+      // failed to read values
+      continue;
     }
+
+    filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
+
+    if (detectApogee(kalmanFilterState) || elapsedTime > KALMAN_FILTER_DROGUE_TIMEOUT) {
+      // ejectDrogueParachute();
+      newFlightPhase(DROGUE_DESCENT);
+      return;
+    }
+  }
 }
 
 /**
@@ -278,118 +233,96 @@ void parachutesControlCoastRoutine(
  * Once that altitude has been reached, eject the main parachute
  * and update the current flight phase.
  */
-void parachutesControlDrogueDescentRoutine(
-    AccelGyroMagnetismData* accelGyroMagnetismData,
-    BarometerData* barometerData
-)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t elapsedTime = 0;
+void parachutesControlDrogueDescentRoutine(AccelGyroMagnetismData* accelGyroMagnetismData,
+                                           BarometerData* barometerData) {
+  uint32_t prevWakeTime = osKernelSysTick();
+  uint32_t elapsedTime = 0;
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
 
-        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
+    elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
 
-        if (elapsedTime > PARACHUTE_PULSE_DURATION)
-        {
-            //closeDrogueParachute();
-        }
-
-        int32_t currentAccel = readAccel(accelGyroMagnetismData);
-        int32_t currentPressure = readPressure(barometerData);
-
-        if (currentAccel == -1 || currentPressure == -1)
-        {
-            // failed to read values
-            continue;
-        }
-
-        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        // detect 4600 ft above sea level and eject main parachute
-        if (detectMainDeploymentAltitude(kalmanFilterState) || elapsedTime > KALMAN_FILTER_MAIN_TIMEOUT)
-        {
-            ejectMainParachute();
-            newFlightPhase(MAIN_DESCENT);
-            return;
-        }
+    if (elapsedTime > PARACHUTE_PULSE_DURATION) {
+      // closeDrogueParachute();
     }
+
+    int32_t currentAccel = readAccel(accelGyroMagnetismData);
+    int32_t currentPressure = readPressure(barometerData);
+
+    if (currentAccel == -1 || currentPressure == -1) {
+      // failed to read values
+      continue;
+    }
+
+    filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
+
+    // detect 4600 ft above sea level and eject main parachute
+    if (detectMainDeploymentAltitude(kalmanFilterState) || elapsedTime > KALMAN_FILTER_MAIN_TIMEOUT) {
+      ejectMainParachute();
+      newFlightPhase(MAIN_DESCENT);
+      return;
+    }
+  }
 }
 
 // this task just ensures the gpios for the parachutes are turned off after 3 seconds
-void parachutesControlMainDescentRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t elapsedTime = 0;
+void parachutesControlMainDescentRoutine() {
+  uint32_t prevWakeTime = osKernelSysTick();
+  uint32_t elapsedTime = 0;
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
 
-        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
+    elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
 
-        if (elapsedTime > PARACHUTE_PULSE_DURATION)
-        {
-            //closeDrogueParachute();
-            closeMainParachute();
-        }
+    if (elapsedTime > PARACHUTE_PULSE_DURATION) {
+      // closeDrogueParachute();
+      closeMainParachute();
     }
+  }
 }
 
-void parachutesControlTask(void const* arg)
-{
-    ParachutesControlData* data = (ParachutesControlData*) arg;
-    kalmanFilterState.altitude = SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL;
-    kalmanFilterState.velocity = 0;
-    kalmanFilterState.acceleration = 0;
+void parachutesControlTask(void const* arg) {
+  ParachutesControlData* data = (ParachutesControlData*)arg;
+  kalmanFilterState.altitude = SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL;
+  kalmanFilterState.velocity = 0;
+  kalmanFilterState.acceleration = 0;
 
-    for (;;)
-    {
-        switch (getCurrentFlightPhase())
-        {
-            case PRELAUNCH:
-            case ARM:
-                parachutesControlPrelaunchRoutine();
-                break;
+  for (;;) {
+    switch (getCurrentFlightPhase()) {
+      case PRELAUNCH:
+      case ARM:
+        parachutesControlPrelaunchRoutine();
+        break;
 
-            case BURN:
-                parachutesControlBurnRoutine(
-                    data->accelGyroMagnetismData_,
-                    data->barometerData_
-                );
-                break;
+      case BURN:
+        parachutesControlBurnRoutine(data->accelGyroMagnetismData_, data->barometerData_);
+        break;
 
-            case COAST:
-                parachutesControlCoastRoutine(
-                    data->accelGyroMagnetismData_,
-                    data->barometerData_
-                );
-                break;
+      case COAST:
+        parachutesControlCoastRoutine(data->accelGyroMagnetismData_, data->barometerData_);
+        break;
 
-            case DROGUE_DESCENT:
-                parachutesControlDrogueDescentRoutine(
-                    data->accelGyroMagnetismData_,
-                    data->barometerData_
-                );
+      case DROGUE_DESCENT:
+        parachutesControlDrogueDescentRoutine(data->accelGyroMagnetismData_, data->barometerData_);
 
-                break;
+        break;
 
-            case MAIN_DESCENT:
-                parachutesControlMainDescentRoutine();
-                break;
+      case MAIN_DESCENT:
+        parachutesControlMainDescentRoutine();
+        break;
 
-            case ABORT_COMMAND_RECEIVED:
-            case ABORT_OXIDIZER_PRESSURE:
-            case ABORT_UNSPECIFIED_REASON:
-            case ABORT_COMMUNICATION_ERROR:
-                // do nothing
-                osDelay(MONITOR_FOR_PARACHUTES_PERIOD);
-                break;
+      case ABORT_COMMAND_RECEIVED:
+      case ABORT_OXIDIZER_PRESSURE:
+      case ABORT_UNSPECIFIED_REASON:
+      case ABORT_COMMUNICATION_ERROR:
+        // do nothing
+        osDelay(MONITOR_FOR_PARACHUTES_PERIOD);
+        break;
 
-            default:
-                break;
-        }
+      default:
+        break;
     }
+  }
 }

--- a/Core/Src/ReadAccelGyroMagnetism.c
+++ b/Core/Src/ReadAccelGyroMagnetism.c
@@ -1,10 +1,9 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
 #include "ReadAccelGyroMagnetism.h"
 
 #include "Data.h"
+#include "cmsis_os.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
 
 static int READ_ACCEL_GYRO_MAGNETISM = 25;
 
@@ -16,9 +15,9 @@ static const int CMD_TIMEOUT = 150;
 #define MAGNETO_MASK 0x40
 
 // Register addresses
-#define G1_CTRL_REGISTER_ADDR 0x10 // CTRL_REG1_G (10h)
-#define XL6_CTRL_REGISTER_ADDR 0x20 // CTRL_REG6_XL (20h)
-#define M3_CTRL_REGISTER_ADDR 0x22 // CTRL_REG3_M (22h)
+#define G1_CTRL_REGISTER_ADDR 0x10   // CTRL_REG1_G (10h)
+#define XL6_CTRL_REGISTER_ADDR 0x20  // CTRL_REG6_XL (20h)
+#define M3_CTRL_REGISTER_ADDR 0x22   // CTRL_REG3_M (22h)
 // #define WHOAMI_REGISTER_ADDR 0x0F
 // #define WHOAMIM_REGISTER_ADDR 0x0F
 
@@ -26,14 +25,14 @@ static const int CMD_TIMEOUT = 150;
 #define ACCEL_X_LOW_REGISTER_ADDR 0x28
 #define MAGNETO_X_LOW_REGISTER_ADDR 0x28
 
-#define ACCEL_SENSITIVITY 0.732 // Unit is mg/LSB
-#define GYRO_SENSITIVITY 8.75  // Unit is mdps/LSB
-#define MAGENTO_SENSITIVITY 0.14 // Unit is mgauss/LSB
+#define ACCEL_SENSITIVITY 0.732   // Unit is mg/LSB
+#define GYRO_SENSITIVITY 8.75     // Unit is mdps/LSB
+#define MAGENTO_SENSITIVITY 0.14  // Unit is mgauss/LSB
 
 // Full Commands
 static const uint8_t ACTIVATE_GYRO_ACCEL_CMD = G1_CTRL_REGISTER_ADDR | WRITE_CMD_MASK;
 // 011 00 0 00 -> ODR 119, 245 DPS
-static const uint8_t ACTIVATE_GYRO_ACCEL_DATA = 0x60;   // ODR 119 has cutoff of 38Hz
+static const uint8_t ACTIVATE_GYRO_ACCEL_DATA = 0x60;  // ODR 119 has cutoff of 38Hz
 
 static const uint8_t SET_ACCEL_SCALE_CMD = XL6_CTRL_REGISTER_ADDR | WRITE_CMD_MASK;
 // 011 01 0 00 -> ODR 119, +/- 16G
@@ -49,89 +48,86 @@ static const uint8_t READ_MAGNETO_X_LOW_CMD = MAGNETO_X_LOW_REGISTER_ADDR | READ
 // static const uint8_t READ_WHOAMI_CMD = WHOAMI_REGISTER_ADDR | READ_CMD_MASK | ACCEL_GYRO_MASK;
 // static const uint8_t READ_WHOAMIM_CMD = WHOAMIM_REGISTER_ADDR | READ_CMD_MASK | MAGNETO_MASK;
 
-void readAccelGyroMagnetismTask(void const* arg)
-{
-    AccelGyroMagnetismData* data = (AccelGyroMagnetismData*) arg;
-    uint32_t prevWakeTime = osKernelSysTick();
+void readAccelGyroMagnetismTask(void const* arg) {
+  AccelGyroMagnetismData* data = (AccelGyroMagnetismData*)arg;
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    osDelay(1000);
+  osDelay(1000);
 
+  HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
+  HAL_SPI_Transmit(&hspi1, &READ_GYRO_X_G_LOW_CMD, 1, CMD_TIMEOUT);
+  HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
+
+  HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
+  HAL_SPI_Transmit(&hspi1, &ACTIVATE_GYRO_ACCEL_CMD, 1, CMD_TIMEOUT);
+  HAL_SPI_Transmit(&hspi1, &ACTIVATE_GYRO_ACCEL_DATA, 1, CMD_TIMEOUT);
+  HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
+
+  HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
+  HAL_SPI_Transmit(&hspi1, &SET_ACCEL_SCALE_CMD, 1, CMD_TIMEOUT);
+  HAL_SPI_Transmit(&hspi1, &SET_ACCEL_SCALE_DATA, 1, CMD_TIMEOUT);
+  HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
+
+  HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
+  HAL_SPI_Transmit(&hspi1, &ACTIVATE_MAGNETO_CMD, 1, CMD_TIMEOUT);
+  HAL_SPI_Transmit(&hspi1, &ACTIVATE_MAGNETO_DATA, 1, CMD_TIMEOUT);
+  HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
+
+  /* Read WHO AM I register for verification, should read 104. */
+  // uint8_t whoami;
+  // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
+  // HAL_SPI_Transmit(&hspi1, &READ_WHOAMIM_CMD, 1, CMD_TIMEOUT);
+  // HAL_SPI_Receive(&hspi1, &whoami, 1, CMD_TIMEOUT);
+  // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
+
+  uint8_t dataBuffer[6];
+
+  int16_t accelX, accelY, accelZ;
+  int16_t gyroX, gyroY, gyroZ;
+  int16_t magnetoX, magnetoY, magnetoZ;
+
+  for (;;) {
+    osDelayUntil(&prevWakeTime, READ_ACCEL_GYRO_MAGNETISM);
+
+    // READ------------------------------------------------------
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
     HAL_SPI_Transmit(&hspi1, &READ_GYRO_X_G_LOW_CMD, 1, CMD_TIMEOUT);
+    HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
+    gyroX = (dataBuffer[1] << 8) | (dataBuffer[0]);
+    gyroY = (dataBuffer[3] << 8) | (dataBuffer[2]);
+    gyroZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
 
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_GYRO_ACCEL_CMD, 1, CMD_TIMEOUT);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_GYRO_ACCEL_DATA, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&hspi1, &READ_ACCEL_X_LOW_CMD, 1, CMD_TIMEOUT);
+    HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
+    accelX = (dataBuffer[1] << 8) | (dataBuffer[0]);
+    accelY = (dataBuffer[3] << 8) | (dataBuffer[2]);
+    accelZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
 
-    HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, &SET_ACCEL_SCALE_CMD, 1, CMD_TIMEOUT);
-    HAL_SPI_Transmit(&hspi1, &SET_ACCEL_SCALE_DATA, 1, CMD_TIMEOUT);
-    HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
-
-    HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_MAGNETO_CMD, 1, CMD_TIMEOUT);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_MAGNETO_DATA, 1, CMD_TIMEOUT);
-    HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
-
-    /* Read WHO AM I register for verification, should read 104. */
-    // uint8_t whoami;
     // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
-    // HAL_SPI_Transmit(&hspi1, &READ_WHOAMIM_CMD, 1, CMD_TIMEOUT);
-    // HAL_SPI_Receive(&hspi1, &whoami, 1, CMD_TIMEOUT);
+    // HAL_SPI_Transmit(&hspi1, &READ_MAGNETO_X_LOW_CMD, 1, CMD_TIMEOUT);
+    // HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
     // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
+    // magnetoX = (dataBuffer[1] << 8) | (dataBuffer[0]);
+    // magnetoY = (dataBuffer[3] << 8) | (dataBuffer[2]);
+    // magnetoZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
 
-    uint8_t dataBuffer[6];
-
-    int16_t accelX, accelY, accelZ;
-    int16_t gyroX, gyroY, gyroZ;
-    int16_t magnetoX, magnetoY, magnetoZ;
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, READ_ACCEL_GYRO_MAGNETISM);
-
-        //READ------------------------------------------------------
-        HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi1, &READ_GYRO_X_G_LOW_CMD, 1, CMD_TIMEOUT);
-        HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
-        HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
-        gyroX = (dataBuffer[1] << 8) | (dataBuffer[0]);
-        gyroY = (dataBuffer[3] << 8) | (dataBuffer[2]);
-        gyroZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
-
-        HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi1, &READ_ACCEL_X_LOW_CMD, 1, CMD_TIMEOUT);
-        HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
-        HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
-        accelX = (dataBuffer[1] << 8) | (dataBuffer[0]);
-        accelY = (dataBuffer[3] << 8) | (dataBuffer[2]);
-        accelZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
-
-        // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
-        // HAL_SPI_Transmit(&hspi1, &READ_MAGNETO_X_LOW_CMD, 1, CMD_TIMEOUT);
-        // HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
-        // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
-        // magnetoX = (dataBuffer[1] << 8) | (dataBuffer[0]);
-        // magnetoY = (dataBuffer[3] << 8) | (dataBuffer[2]);
-        // magnetoZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
-
-        /* Writeback */
-        if (osMutexWait(data->mutex_, 0) != osOK)
-        {
-            continue;
-        }
-
-        data->accelX_ = accelX * ACCEL_SENSITIVITY; // mg
-        data->accelY_ = accelY * ACCEL_SENSITIVITY; // mg
-        data->accelZ_ = accelZ * ACCEL_SENSITIVITY; // mg
-        data->gyroX_ = gyroX * GYRO_SENSITIVITY; // mdps
-        data->gyroY_ = gyroY * GYRO_SENSITIVITY; // mdps
-        data->gyroZ_ = gyroZ * GYRO_SENSITIVITY; // mdps
-        // data->magnetoX_ = magnetoX * MAGENTO_SENSITIVITY; // mgauss
-        // data->magnetoY_ = magnetoY * MAGENTO_SENSITIVITY; // mgauss
-        // data->magnetoZ_ = magnetoZ * MAGENTO_SENSITIVITY; // mgauss
-        osMutexRelease(data->mutex_);
+    /* Writeback */
+    if (osMutexWait(data->mutex_, 0) != osOK) {
+      continue;
     }
+
+    data->accelX_ = accelX * ACCEL_SENSITIVITY;  // mg
+    data->accelY_ = accelY * ACCEL_SENSITIVITY;  // mg
+    data->accelZ_ = accelZ * ACCEL_SENSITIVITY;  // mg
+    data->gyroX_ = gyroX * GYRO_SENSITIVITY;     // mdps
+    data->gyroY_ = gyroY * GYRO_SENSITIVITY;     // mdps
+    data->gyroZ_ = gyroZ * GYRO_SENSITIVITY;     // mdps
+    // data->magnetoX_ = magnetoX * MAGENTO_SENSITIVITY; // mgauss
+    // data->magnetoY_ = magnetoY * MAGENTO_SENSITIVITY; // mgauss
+    // data->magnetoZ_ = magnetoZ * MAGENTO_SENSITIVITY; // mgauss
+    osMutexRelease(data->mutex_);
+  }
 }

--- a/Core/Src/ReadBarometer.c
+++ b/Core/Src/ReadBarometer.c
@@ -1,44 +1,44 @@
 /**
-  ******************************************************************************
-  * File Name          : ReadBarometer.c
-  * Description        : This file contains constants and functions designed to
-  *                      obtain accurate pressure and temperature readings from
-  *                      the MS5607-02BA03 barometer on the flight board. A
-  *                      thread task is included that will constantly loop,
-  *                      reading and updating the passed BarometerData struct.
-  ******************************************************************************
-*/
+ ******************************************************************************
+ * File Name          : ReadBarometer.c
+ * Description        : This file contains constants and functions designed to
+ *                      obtain accurate pressure and temperature readings from
+ *                      the MS5607-02BA03 barometer on the flight board. A
+ *                      thread task is included that will constantly loop,
+ *                      reading and updating the passed BarometerData struct.
+ ******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
 
+#include "ReadBarometer.h"
+
+#include "Data.h"
+#include "cmsis_os.h"
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "ReadBarometer.h"
-#include "Data.h"
 
 /* Macros --------------------------------------------------------------------*/
 
 /* Constants -----------------------------------------------------------------*/
 
-static const int READ_BAROMETER_PERIOD      = 25;
-static const int TEMP_LOW                   = 2000;
-static const int TEMP_VERY_LOW              = -1500;
-static const int CMD_SIZE                   = 1;
-static const int CMD_TIMEOUT                = 150;
+static const int READ_BAROMETER_PERIOD = 25;
+static const int TEMP_LOW = 2000;
+static const int TEMP_VERY_LOW = -1500;
+static const int CMD_SIZE = 1;
+static const int CMD_TIMEOUT = 150;
 
-static const uint8_t ADC_D1_512_CONV_CMD    = 0x42;
-static const uint8_t ADC_D2_512_CONV_CMD    = 0x52;
-static const uint8_t ADC_READ_CMD           = 0x00;
-static const uint8_t PROM_READ_SENS_CMD     = 0xA2;
-static const uint8_t PROM_READ_OFF_CMD      = 0xA4;
-static const uint8_t PROM_READ_TCS_CMD      = 0xA6;
-static const uint8_t PROM_READ_TCO_CMD      = 0xA8;
-static const uint8_t PROM_READ_TREF_CMD     = 0xAA;
+static const uint8_t ADC_D1_512_CONV_CMD = 0x42;
+static const uint8_t ADC_D2_512_CONV_CMD = 0x52;
+static const uint8_t ADC_READ_CMD = 0x00;
+static const uint8_t PROM_READ_SENS_CMD = 0xA2;
+static const uint8_t PROM_READ_OFF_CMD = 0xA4;
+static const uint8_t PROM_READ_TCS_CMD = 0xA6;
+static const uint8_t PROM_READ_TCO_CMD = 0xA8;
+static const uint8_t PROM_READ_TREF_CMD = 0xAA;
 static const uint8_t PROM_READ_TEMPSENS_CMD = 0xAC;
-static const uint8_t READ_BYTE_CMD          = 0x00;
-static const uint8_t RESET_CMD              = 0x1E;
+static const uint8_t READ_BYTE_CMD = 0x00;
+static const uint8_t RESET_CMD = 0x1E;
 
 /* Variables -----------------------------------------------------------------*/
 
@@ -56,161 +56,158 @@ uint16_t readCalibrationCoefficient(const uint8_t PROM_READ_CMD);
  *
  * @param   arg A pointer to the BarometerData struct that will be updated.
  */
-void readBarometerTask(void const* arg)
-{
-    /**
-     * Variable Descriptions from MS5607-02BA03 Data Sheet:
-     *
-     * C1 (SENSt1)      - Pressure sensitivity
-     * C2 (OFFt1)       - Pressure offset
-     * C3 (TCS)         - Temperature coefficient of pressure sensitivity
-     * C4 (TCO)         - Temperature coefficient of pressure offset
-     * C5 (Tref)        - Reference temperature
-     * C6 (TEMPSENS)    - Temperature coefficient of the temperature
-     *
-     * D1   - Digital pressure value
-     * D2   - Digital temperature value
-     *
-     * dT   - Difference between actual and reference temperature
-     *          dT = D2 - Tref = D2 - (C5 * 2^8)
-     * TEMP - Actual temperature (-40...85°C with 0.01°C resolution)
-     *          TEMP = 20°C + (dT * TEMPSENS) = 2000 + (dT * C6)/2^23
-     * OFF  - Offset at actual temperature
-     *          OFF = OFFt1 + (TCO * dT) = (C2 * 2^17) + (C4 * dT)/2^6
-     * SENS - Sensitivity at actual temperature
-     *          SENS = SENSt1 + (TCS * dT) = (C1 * 2^16) + (C3 * dT)/2^7
-     * P    - Temperature compensated pressure (10...1200mbar with 0.01mbar resolution)
-     *          P = (D1 * SENS) - OFF = ((D1 * SENS)/2^21 - OFF)/2^15
-     */
+void readBarometerTask(void const* arg) {
+  /**
+   * Variable Descriptions from MS5607-02BA03 Data Sheet:
+   *
+   * C1 (SENSt1)      - Pressure sensitivity
+   * C2 (OFFt1)       - Pressure offset
+   * C3 (TCS)         - Temperature coefficient of pressure sensitivity
+   * C4 (TCO)         - Temperature coefficient of pressure offset
+   * C5 (Tref)        - Reference temperature
+   * C6 (TEMPSENS)    - Temperature coefficient of the temperature
+   *
+   * D1   - Digital pressure value
+   * D2   - Digital temperature value
+   *
+   * dT   - Difference between actual and reference temperature
+   *          dT = D2 - Tref = D2 - (C5 * 2^8)
+   * TEMP - Actual temperature (-40...85°C with 0.01°C resolution)
+   *          TEMP = 20°C + (dT * TEMPSENS) = 2000 + (dT * C6)/2^23
+   * OFF  - Offset at actual temperature
+   *          OFF = OFFt1 + (TCO * dT) = (C2 * 2^17) + (C4 * dT)/2^6
+   * SENS - Sensitivity at actual temperature
+   *          SENS = SENSt1 + (TCS * dT) = (C1 * 2^16) + (C3 * dT)/2^7
+   * P    - Temperature compensated pressure (10...1200mbar with 0.01mbar resolution)
+   *          P = (D1 * SENS) - OFF = ((D1 * SENS)/2^21 - OFF)/2^15
+   */
 
-    // Variables
-    BarometerData* data         = (BarometerData*) arg;
-    uint32_t prevWakeTime       = osKernelSysTick();
-    uint32_t pressureReading    = 0;    // Stores a 24 bit value
-    uint32_t temperatureReading = 0;    // Stores a 24 bit value
-    uint8_t dataInBuffer;
+  // Variables
+  BarometerData* data = (BarometerData*)arg;
+  uint32_t prevWakeTime = osKernelSysTick();
+  uint32_t pressureReading = 0;     // Stores a 24 bit value
+  uint32_t temperatureReading = 0;  // Stores a 24 bit value
+  uint8_t dataInBuffer;
 
-    // Reset the barometer
+  // Reset the barometer
+  HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
+  HAL_SPI_Transmit(&hspi3, &RESET_CMD, CMD_SIZE, CMD_TIMEOUT);
+  osDelay(3);  // 2.8ms reload after Reset command
+  HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
+
+  // Read PROM for calibration coefficients
+  uint16_t c1Sens = readCalibrationCoefficient(PROM_READ_SENS_CMD);
+  uint16_t c2Off = readCalibrationCoefficient(PROM_READ_OFF_CMD);
+  uint16_t c3Tcs = readCalibrationCoefficient(PROM_READ_TCS_CMD);
+  uint16_t c4Tco = readCalibrationCoefficient(PROM_READ_TCO_CMD);
+  uint16_t c5Tref = readCalibrationCoefficient(PROM_READ_TREF_CMD);
+  uint16_t c6Tempsens = readCalibrationCoefficient(PROM_READ_TEMPSENS_CMD);
+
+  /**
+   * Repeatedly read digital pressure and temperature.
+   * Convert these values into their calibrated counterparts.
+   * Finally, update the data globally if the mutex is available.
+   */
+  for (;;) {
+    osDelayUntil(&prevWakeTime, READ_BAROMETER_PERIOD);
+
+    /* Read Digital Pressure (D1) ----------------------------------------*/
+
+    // Tell the barometer to convert the pressure to a digital value with an over-sampling ratio of 512
     HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi3, &RESET_CMD, CMD_SIZE, CMD_TIMEOUT);
-    osDelay(3); // 2.8ms reload after Reset command
+    HAL_SPI_Transmit(&hspi3, &ADC_D1_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
     HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
 
-    // Read PROM for calibration coefficients
-    uint16_t c1Sens     = readCalibrationCoefficient(PROM_READ_SENS_CMD);
-    uint16_t c2Off      = readCalibrationCoefficient(PROM_READ_OFF_CMD);
-    uint16_t c3Tcs      = readCalibrationCoefficient(PROM_READ_TCS_CMD);
-    uint16_t c4Tco      = readCalibrationCoefficient(PROM_READ_TCO_CMD);
-    uint16_t c5Tref     = readCalibrationCoefficient(PROM_READ_TREF_CMD);
-    uint16_t c6Tempsens = readCalibrationCoefficient(PROM_READ_TEMPSENS_CMD);
+    osDelay(2);  // 1.17ms max conversion time for an over-sampling ratio of 512
 
-    /**
-     * Repeatedly read digital pressure and temperature.
-     * Convert these values into their calibrated counterparts.
-     * Finally, update the data globally if the mutex is available.
-     */
-    for (;;)
+    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
+
+    HAL_SPI_Transmit(&hspi3, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
+
+    // Read the first byte (bits 23-16)
+    HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    pressureReading = dataInBuffer << 16;
+
+    // Read the second byte (bits 15-8)
+    HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    pressureReading += dataInBuffer << 8;
+
+    // Read the third byte (bits 7-0)
+    HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    pressureReading += dataInBuffer;
+
+    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
+
+    /* Read Digital Temperature (D2) -------------------------------------*/
+
+    // Tell the barometer to convert the temperature to a digital value with an over-sampling ratio of 512
+    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
+    HAL_SPI_Transmit(&hspi3, &ADC_D2_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
+    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
+
+    osDelay(2);  // 1.17ms max conversion time for an over-sampling ratio of 512
+
+    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
+
+    HAL_SPI_Transmit(&hspi3, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
+
+    // Read the first byte (bits 23-16)
+    HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    temperatureReading = dataInBuffer << 16;
+
+    // Read the second byte (bits 15-8)
+    HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    temperatureReading += dataInBuffer << 8;
+
+    // Read the third byte (bits 7-0)
+    HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    temperatureReading += dataInBuffer;
+
+    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
+
+    /* Calculate First-Order Temperature and Parameters ------------------*/
+
+    // Calibration coefficients need to be type cast to int64_t to avoid overflow during intermediate calculations
+    int32_t dT = temperatureReading - ((int32_t)c5Tref << 8);
+    int32_t temp = 2000 + ((dT * (int64_t)c6Tempsens) >> 23);  // Divide this value by 100 to get degrees Celsius
+    int64_t off = ((int64_t)c2Off << 17) + ((dT * (int64_t)c4Tco) >> 6);
+    int64_t sens = ((int64_t)c1Sens << 16) + ((dT * (int64_t)c3Tcs) >> 7);
+
+    /* Calculate Second-Order Temperature and Pressure -------------------*/
+
+    if (temp < TEMP_LOW)  // If the temperature is below 20°C
     {
-        osDelayUntil(&prevWakeTime, READ_BAROMETER_PERIOD);
+      int32_t t2 = ((int64_t)dT * dT) >> 31;
+      int64_t off2 = 61 * (((int64_t)(temp - 2000) * (temp - 2000)) >> 4);
+      int64_t sens2 = 2 * ((int64_t)(temp - 2000) * (temp - 2000));
 
-        /* Read Digital Pressure (D1) ----------------------------------------*/
+      if (temp < TEMP_VERY_LOW)  // If the temperature is below -15°C
+      {
+        off2 = off2 + (15 * ((int64_t)(temp + 1500) * (temp + 1500)));
+        sens2 = sens2 + (8 * ((int64_t)(temp + 1500) * (temp + 1500)));
+      }
 
-        // Tell the barometer to convert the pressure to a digital value with an over-sampling ratio of 512
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi3, &ADC_D1_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
-
-        osDelay(2); // 1.17ms max conversion time for an over-sampling ratio of 512
-
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-
-        HAL_SPI_Transmit(&hspi3, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
-
-        // Read the first byte (bits 23-16)
-        HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-        pressureReading = dataInBuffer << 16;
-
-        // Read the second byte (bits 15-8)
-        HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-        pressureReading += dataInBuffer << 8;
-
-        // Read the third byte (bits 7-0)
-        HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-        pressureReading += dataInBuffer;
-
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
-
-        /* Read Digital Temperature (D2) -------------------------------------*/
-
-        // Tell the barometer to convert the temperature to a digital value with an over-sampling ratio of 512
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi3, &ADC_D2_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
-
-        osDelay(2); // 1.17ms max conversion time for an over-sampling ratio of 512
-
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-
-        HAL_SPI_Transmit(&hspi3, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
-
-        // Read the first byte (bits 23-16)
-        HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-        temperatureReading = dataInBuffer << 16;
-
-        // Read the second byte (bits 15-8)
-        HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-        temperatureReading += dataInBuffer << 8;
-
-        // Read the third byte (bits 7-0)
-        HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-        temperatureReading += dataInBuffer;
-
-        HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
-
-        /* Calculate First-Order Temperature and Parameters ------------------*/
-
-        // Calibration coefficients need to be type cast to int64_t to avoid overflow during intermediate calculations
-        int32_t dT      = temperatureReading - ((int32_t) c5Tref << 8);
-        int32_t temp    = 2000 + ((dT * (int64_t) c6Tempsens) >> 23); // Divide this value by 100 to get degrees Celsius
-        int64_t off     = ((int64_t) c2Off << 17) + ((dT * (int64_t) c4Tco) >> 6);
-        int64_t sens    = ((int64_t) c1Sens << 16) + ((dT * (int64_t) c3Tcs) >> 7);
-
-        /* Calculate Second-Order Temperature and Pressure -------------------*/
-
-        if (temp < TEMP_LOW)    // If the temperature is below 20°C
-        {
-            int32_t t2      = ((int64_t) dT * dT) >> 31;
-            int64_t off2    = 61 * (((int64_t) (temp - 2000) * (temp - 2000)) >> 4);
-            int64_t sens2   = 2 * ((int64_t) (temp - 2000) * (temp - 2000));
-
-            if (temp < TEMP_VERY_LOW)   // If the temperature is below -15°C
-            {
-                off2    = off2 + (15 * ((int64_t) (temp + 1500) * (temp + 1500)));
-                sens2   = sens2 + (8 * ((int64_t) (temp + 1500) * (temp + 1500)));
-            }
-
-            temp    = temp  - t2;
-            off     = off   - off2;
-            sens    = sens  - sens2;
-        }
-
-        int32_t p   = (((pressureReading * sens) >> 21) - off) >> 15;   // Divide this value by 100 to get millibars
-
-        /* Store Data --------------------------------------------------------*/
-
-        if (osMutexWait(data->mutex_, 0) == osOK)
-        {
-            data->pressure_     = p;
-            data->temperature_  = temp;
-            osMutexRelease(data->mutex_);
-        }
-
-        // All equations provided by MS5607-02BA03 data sheet
-
-        // PRESSURE AND TEMPERATURE VALUES ARE STORED AT 100x VALUE TO MAINTAIN
-        // 2 DECIMAL POINTS OF PRECISION AS AN INTEGER!
-        // E.x. The value 1234 should be interpreted as 12.34
+      temp = temp - t2;
+      off = off - off2;
+      sens = sens - sens2;
     }
+
+    int32_t p = (((pressureReading * sens) >> 21) - off) >> 15;  // Divide this value by 100 to get millibars
+
+    /* Store Data --------------------------------------------------------*/
+
+    if (osMutexWait(data->mutex_, 0) == osOK) {
+      data->pressure_ = p;
+      data->temperature_ = temp;
+      osMutexRelease(data->mutex_);
+    }
+
+    // All equations provided by MS5607-02BA03 data sheet
+
+    // PRESSURE AND TEMPERATURE VALUES ARE STORED AT 100x VALUE TO MAINTAIN
+    // 2 DECIMAL POINTS OF PRECISION AS AN INTEGER!
+    // E.x. The value 1234 should be interpreted as 12.34
+  }
 }
 
 /**
@@ -219,24 +216,23 @@ void readBarometerTask(void const* arg)
  *                          coefficient. See the data sheet for the commands.
  * @return                  The read coefficient.
  */
-uint16_t readCalibrationCoefficient(const uint8_t PROM_READ_CMD)
-{
-    uint16_t coefficient;
-    uint8_t dataInBuffer;
+uint16_t readCalibrationCoefficient(const uint8_t PROM_READ_CMD) {
+  uint16_t coefficient;
+  uint8_t dataInBuffer;
 
-    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
 
-    HAL_SPI_Transmit(&hspi3, &PROM_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
+  HAL_SPI_Transmit(&hspi3, &PROM_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
 
-    // Read the first byte (bits 15-8)
-    HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-    coefficient = dataInBuffer << 8;
+  // Read the first byte (bits 15-8)
+  HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+  coefficient = dataInBuffer << 8;
 
-    // Read the second byte (bits 7-0)
-    HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
-    coefficient += dataInBuffer;
+  // Read the second byte (bits 7-0)
+  HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+  coefficient += dataInBuffer;
 
-    HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
 
-    return coefficient;
+  return coefficient;
 }

--- a/Core/Src/ReadBatteryVoltage.c
+++ b/Core/Src/ReadBatteryVoltage.c
@@ -1,29 +1,28 @@
 /**
-  ******************************************************************************
-  * File Name          : ReadBatteryVoltage.c
-  * Description        : This file contains constants and functions designed to
-  *                      read the voltage of the battery used to power the DMB.
-  *                      The voltage first goes through a voltage divider, so
-  *                      the reading =will initially be 1/4 the actual value.
-  ******************************************************************************
-*/
+ ******************************************************************************
+ * File Name          : ReadBatteryVoltage.c
+ * Description        : This file contains constants and functions designed to
+ *                      read the voltage of the battery used to power the DMB.
+ *                      The voltage first goes through a voltage divider, so
+ *                      the reading =will initially be 1/4 the actual value.
+ ******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
-
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
 
 #include "ReadBatteryVoltage.h"
 
 #include "Data.h"
+#include "cmsis_os.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
 
 /* Constants -----------------------------------------------------------------*/
 
 static const int BATTERY_VOLTAGE_ADC_POLL_TIMEOUT = 50;
 static const int READ_BATTERY_VOLTAGE_PERIOD = 1000;
 
-static const double ADC_SCALE = 2000.0 / 2797.0; // TODO: Figure out why
+static const double ADC_SCALE = 2000.0 / 2797.0;  // TODO: Figure out why
 static const double VOLTAGE_DIVIDER_SCALE = 4;
 
 /* Functions -----------------------------------------------------------------*/
@@ -35,24 +34,24 @@ static const double VOLTAGE_DIVIDER_SCALE = 4;
  * @param   arg A pointer to the BatteryVoltageData struct that will be updated.
  */
 void readBatteryVoltageTask(void const* arg) {
-    BatteryVoltageData* data = (BatteryVoltageData*) arg;
-    uint32_t prevWakeTime = osKernelSysTick();
+  BatteryVoltageData* data = (BatteryVoltageData*)arg;
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    uint32_t batteryVoltageValue = 0;
+  uint32_t batteryVoltageValue = 0;
 
-    HAL_ADC_Start(&hadc2);  // Enables ADC and starts conversion of regular channels
+  HAL_ADC_Start(&hadc2);  // Enables ADC and starts conversion of regular channels
 
-    for (;;) {
-        osDelayUntil(&prevWakeTime, READ_BATTERY_VOLTAGE_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, READ_BATTERY_VOLTAGE_PERIOD);
 
-        if (HAL_ADC_PollForConversion(&hadc2, BATTERY_VOLTAGE_ADC_POLL_TIMEOUT) == HAL_OK) {
-            batteryVoltageValue = HAL_ADC_GetValue(&hadc2);
-            batteryVoltageValue = batteryVoltageValue * ADC_SCALE * VOLTAGE_DIVIDER_SCALE;
+    if (HAL_ADC_PollForConversion(&hadc2, BATTERY_VOLTAGE_ADC_POLL_TIMEOUT) == HAL_OK) {
+      batteryVoltageValue = HAL_ADC_GetValue(&hadc2);
+      batteryVoltageValue = batteryVoltageValue * ADC_SCALE * VOLTAGE_DIVIDER_SCALE;
 
-			if (osMutexWait(data->mutex_, 0) == osOK) {
-				data->voltage_ = batteryVoltageValue;
-				osMutexRelease(data->mutex_);
-			}
-        }
+      if (osMutexWait(data->mutex_, 0) == osOK) {
+        data->voltage_ = batteryVoltageValue;
+        osMutexRelease(data->mutex_);
+      }
     }
+  }
 }

--- a/Core/Src/ReadCombustionChamberPressure.c
+++ b/Core/Src/ReadCombustionChamberPressure.c
@@ -1,66 +1,61 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-#include "math.h"
-
 #include "ReadCombustionChamberPressure.h"
 
 #include "Data.h"
 #include "Utils.h"
+#include "cmsis_os.h"
+#include "math.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
 
 #define QUEUE_SIZE 5
 
 static int READ_COMBUSTION_CHAMBER_PRESSURE_PERIOD = 50;
 
 static const int COMBUSTION_CHAMBER_ADC_POLL_TIMEOUT = 50;
-static const double R1 = 100;    // Resistor values in kOhms
+static const double R1 = 100;  // Resistor values in kOhms
 static const double R2 = 133;
 
 static uint16_t combustionChamberValuesQueue[QUEUE_SIZE] = {0};
 
-void readCombustionChamberPressureTask(void const* arg)
-{
-    CombustionChamberPressureData* data = (CombustionChamberPressureData* ) arg;
-    uint32_t prevWakeTime = osKernelSysTick();
+void readCombustionChamberPressureTask(void const* arg) {
+  CombustionChamberPressureData* data = (CombustionChamberPressureData*)arg;
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    double vo = 0;  // The voltage across the 133k resistor
-    double vi = 0;  // The pressure sensor output
-    double chamberPressure = 0;
+  double vo = 0;  // The voltage across the 133k resistor
+  double vi = 0;  // The pressure sensor output
+  double chamberPressure = 0;
 
-    int combustionChamberQueueIndex = 0;
+  int combustionChamberQueueIndex = 0;
 
-    HAL_ADC_Start(&hadc1);  // Enables ADC and starts conversion of regular channels
+  HAL_ADC_Start(&hadc1);  // Enables ADC and starts conversion of regular channels
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, READ_COMBUSTION_CHAMBER_PRESSURE_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, READ_COMBUSTION_CHAMBER_PRESSURE_PERIOD);
 
-        if (HAL_ADC_PollForConversion(&hadc1, COMBUSTION_CHAMBER_ADC_POLL_TIMEOUT) == HAL_OK)
-        {
-            combustionChamberValuesQueue[combustionChamberQueueIndex++] = HAL_ADC_GetValue(&hadc1);
-        }
-
-        uint16_t adcRead = averageArray(combustionChamberValuesQueue, QUEUE_SIZE);
-
-        vo = 3.3 / (pow(2, 12) - 1) * adcRead;    // Calculate voltage from the 12 bit ADC reading
-
-        // vi to voltage divider varies between 0.5V-4.5V, but the board requires a voltage less than 3.3V.
-        // After the voltage divider, the voltage varies between 0.285V-2.57V
-        vi = (R2 + R1) / R2 * vo;   // Calculate the original voltage output of the sensor
-
-        // The pressure sensor is ratiometric. The pressure is 0 psi when the voltage is 0.5V, and is 1000
-        // psi when the voltage is 4.5V. The equation is derived from this information.
-        chamberPressure = (vi - 0.5) * 1000 / 4;  // Tank pressure in psi
-        chamberPressure = chamberPressure * 1000;   // Multiply by 1000 to keep decimal places
-
-        combustionChamberQueueIndex %= QUEUE_SIZE;
-
-        if (osMutexWait(data->mutex_, 0) != osOK)
-        {
-            continue;
-        }
-
-        data->pressure_ = (int32_t) chamberPressure;
-        osMutexRelease(data->mutex_);
+    if (HAL_ADC_PollForConversion(&hadc1, COMBUSTION_CHAMBER_ADC_POLL_TIMEOUT) == HAL_OK) {
+      combustionChamberValuesQueue[combustionChamberQueueIndex++] = HAL_ADC_GetValue(&hadc1);
     }
+
+    uint16_t adcRead = averageArray(combustionChamberValuesQueue, QUEUE_SIZE);
+
+    vo = 3.3 / (pow(2, 12) - 1) * adcRead;  // Calculate voltage from the 12 bit ADC reading
+
+    // vi to voltage divider varies between 0.5V-4.5V, but the board requires a voltage less than 3.3V.
+    // After the voltage divider, the voltage varies between 0.285V-2.57V
+    vi = (R2 + R1) / R2 * vo;  // Calculate the original voltage output of the sensor
+
+    // The pressure sensor is ratiometric. The pressure is 0 psi when the voltage is 0.5V, and is 1000
+    // psi when the voltage is 4.5V. The equation is derived from this information.
+    chamberPressure = (vi - 0.5) * 1000 / 4;   // Tank pressure in psi
+    chamberPressure = chamberPressure * 1000;  // Multiply by 1000 to keep decimal places
+
+    combustionChamberQueueIndex %= QUEUE_SIZE;
+
+    if (osMutexWait(data->mutex_, 0) != osOK) {
+      continue;
+    }
+
+    data->pressure_ = (int32_t)chamberPressure;
+    osMutexRelease(data->mutex_);
+  }
 }

--- a/Core/Src/ReadGps.c
+++ b/Core/Src/ReadGps.c
@@ -1,154 +1,143 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
 #include "ReadGps.h"
-
-#include "Data.h"
-#include "main.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "Data.h"
+#include "cmsis_os.h"
+#include "main.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
+
 static int READ_GPS_PERIOD = 250;
 
-void readGpsTask(void const* arg)
-{
-    GpsData* data = (GpsData*) arg;
-    uint32_t prevWakeTime = osKernelSysTick();
+void readGpsTask(void const* arg) {
+  GpsData* data = (GpsData*)arg;
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    HAL_UART_Receive_DMA(&huart4, (uint8_t*) &dma_rx_buffer, NMEA_MAX_LENGTH + 1);
+  HAL_UART_Receive_DMA(&huart4, (uint8_t*)&dma_rx_buffer, NMEA_MAX_LENGTH + 1);
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, READ_GPS_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, READ_GPS_PERIOD);
 
-        if (osMutexWait(data->mutex_, 0) != osOK)
-        {
-            continue;
+    if (osMutexWait(data->mutex_, 0) != osOK) {
+      continue;
+    }
+
+    if (data->parseFlag_ == 1) {
+      // Returns the first token
+      char* gps_item = &data->buffer_[0];
+      uint8_t item_len = 0;
+      uint8_t counter = 0;
+      uint8_t done = 0;
+      char direction;
+      //			HAL_GPIO_TogglePin(LED_3_GPIO_Port, LED_3_Pin);
+
+      // Keeps printing tokens while one of the delimiters present in gps_item
+      do {
+        for (uint8_t i = 0; i < NMEA_MAX_LENGTH + 1; i++) {
+          if (gps_item[i] == ',') {
+            gps_item[i] = 0;
+            item_len = i;
+            break;
+          } else if (gps_item[i] == 0) {
+            done = 1;
+            break;
+          }
         }
 
-        if (data->parseFlag_ == 1)
-        {
-			// Returns the first token
-			char* gps_item = &data->buffer_[0];
-			uint8_t item_len = 0;
-			uint8_t counter = 0;
-			uint8_t done = 0;
-			char direction;
-//			HAL_GPIO_TogglePin(LED_3_GPIO_Port, LED_3_Pin);
+        if (gps_item[0] != 0) {
+          switch (counter) {
+            // case 0 is when gps_item is "$GPGGA"
+            case 1: {
+              data->time_ = (uint32_t)(atof(gps_item) * 100);  // HHMMSS.SS format. Time is multiplied by 100.
+              break;
+            }
 
-			// Keeps printing tokens while one of the delimiters present in gps_item
-			do
-			{
-				for (uint8_t i = 0; i < NMEA_MAX_LENGTH + 1; i++) {
-					if (gps_item[i] == ',') {
-						gps_item[i] = 0;
-						item_len = i;
-						break;
-					} else if (gps_item[i] == 0) {
-						done = 1;
-						break;
-					}
-				}
+            case 2: {
+              double latitude = (atof(gps_item));                  // DDMM.MMMMMM
+              data->latitude_.degrees_ = (int32_t)latitude / 100;  // First 2 numbers are the latitude degrees
+              data->latitude_.minutes_ = (int32_t)((latitude - data->latitude_.degrees_ * 100) *
+                                                   100000);  // Latitude minutes is multplied by 100000
+              break;
+            }
 
-				if (gps_item[0] != 0) {
-					switch (counter)
-					{
-						// case 0 is when gps_item is "$GPGGA"
-						case 1:
-						{
-							data->time_ = (uint32_t) (atof(gps_item) * 100); // HHMMSS.SS format. Time is multiplied by 100.
-							break;
-						}
+            case 3:  // Latitude direction
+            {
+              direction = *gps_item;
 
-						case 2:
-						{
-							double latitude = (atof(gps_item)); // DDMM.MMMMMM
-							data->latitude_.degrees_ = (int32_t) latitude / 100; // First 2 numbers are the latitude degrees
-							data->latitude_.minutes_ = (int32_t) ((latitude - data->latitude_.degrees_ * 100) * 100000); // Latitude minutes is multplied by 100000
-							break;
-						}
+              // N is represented as a positive value
+              // S is represented as a negative value
+              if (direction == 'S') {
+                data->latitude_.degrees_ *= -1;
+                data->latitude_.minutes_ *= -1;
+              }
 
-						case 3:	// Latitude direction
-						{
-							direction = *gps_item;
+              break;
+            }
 
-							// N is represented as a positive value
-							// S is represented as a negative value
-							if (direction == 'S')
-							{
-								data->latitude_.degrees_ *= -1;
-								data->latitude_.minutes_ *= -1;
-							}
+            case 4: {
+              double longitude = (atof(gps_item));                   // DDMM.MMMMMM
+              data->longitude_.degrees_ = (int32_t)longitude / 100;  // First 2 numbers are the longitude degrees
+              data->longitude_.minutes_ = (int32_t)((longitude - data->longitude_.degrees_ * 100) *
+                                                    100000);  // Longitude minutes is multplied by 100000
+              break;
+            }
 
-							break;
-						}
+            case 5:  // Longitude direction
+            {
+              direction = *gps_item;
 
-						case 4:
-						{
-							double longitude = (atof(gps_item)); // DDMM.MMMMMM
-							data->longitude_.degrees_ = (int32_t) longitude / 100; // First 2 numbers are the longitude degrees
-							data->longitude_.minutes_ = (int32_t) ((longitude - data->longitude_.degrees_ * 100) * 100000); // Longitude minutes is multplied by 100000
-							break;
-						}
+              // E is represented as a positive value
+              // W is represented as a negative value
+              if (direction == 'W') {
+                data->longitude_.degrees_ *= -1;
+                data->longitude_.minutes_ *= -1;
+              }
 
-						case 5: // Longitude direction
-						{
-							direction = *gps_item;
+              break;
+            }
 
-							// E is represented as a positive value
-							// W is represented as a negative value
-							if (direction == 'W')
-							{
-								data->longitude_.degrees_ *= -1;
-								data->longitude_.minutes_ *= -1;
-							}
+            case 9: {
+              data->antennaAltitude_.altitude_ =
+                  (int32_t)(atof(gps_item) * 10);  // Antenna altitude is multiplied by 10
+              break;
+            }
 
-							break;
-						}
+            case 10:  // Antenna altitude unit
+            {
+              data->antennaAltitude_.unit_ = *gps_item;
+              break;
+            }
 
-						case 9:
-						{
-							data->antennaAltitude_.altitude_ = (int32_t) (atof(gps_item) * 10); // Antenna altitude is multiplied by 10
-							break;
-						}
+            case 11: {
+              data->geoidAltitude_.altitude_ = (int32_t)(atof(gps_item) * 10);  // Geoid altitude is multiplied by 10
+              break;
+            }
 
-						case 10: // Antenna altitude unit
-						{
-							data->antennaAltitude_.unit_ = *gps_item;
-							break;
-						}
+            case 12:  // Geoid altitude unit
+            {
+              data->geoidAltitude_.unit_ = *gps_item;
+              break;
+            }
 
-						case 11:
-						{
-							data->geoidAltitude_.altitude_ = (int32_t) (atof(gps_item) * 10); // Geoid altitude is multiplied by 10
-							break;
-						}
+            default:
+              break;
+          }
+        }
 
-						case 12: // Geoid altitude unit
-						{
-							data->geoidAltitude_.unit_ = *gps_item;
-							break;
-						}
-
-						default:
-							break;
-					}
-				}
-
-				counter++;
-				gps_item = &gps_item[item_len + 1];
-			} while (done == 0);
-		}
-
-        // Subtract geoid altitude from antenna altitude to get Height Above Ellipsoid (HAE)
-        data->totalAltitude_.altitude_ = data->antennaAltitude_.altitude_ - data->geoidAltitude_.altitude_;
-        data->totalAltitude_.unit_ = data->antennaAltitude_.unit_;
-
-        data->parseFlag_ = 0;
-        memset(dma_rx_buffer, 0, NMEA_MAX_LENGTH+1);
-        osMutexRelease(data->mutex_);
+        counter++;
+        gps_item = &gps_item[item_len + 1];
+      } while (done == 0);
     }
+
+    // Subtract geoid altitude from antenna altitude to get Height Above Ellipsoid (HAE)
+    data->totalAltitude_.altitude_ = data->antennaAltitude_.altitude_ - data->geoidAltitude_.altitude_;
+    data->totalAltitude_.unit_ = data->antennaAltitude_.unit_;
+
+    data->parseFlag_ = 0;
+    memset(dma_rx_buffer, 0, NMEA_MAX_LENGTH + 1);
+    osMutexRelease(data->mutex_);
+  }
 }

--- a/Core/Src/ReadOxidizerTankPressure.c
+++ b/Core/Src/ReadOxidizerTankPressure.c
@@ -1,12 +1,11 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-#include "math.h"
-
 #include "ReadOxidizerTankPressure.h"
 
 #include "Data.h"
 #include "Utils.h"
+#include "cmsis_os.h"
+#include "math.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
 
 #define QUEUE_SIZE 5
 
@@ -16,48 +15,45 @@ static const int OXIDIZER_TANK_POLL_TIMEOUT = 50;
 
 static uint16_t oxidizerTankValuesQueue[QUEUE_SIZE] = {0};
 
-void readOxidizerTankPressureTask(void const* arg)
-{
-    OxidizerTankPressureData* data = (OxidizerTankPressureData* ) arg;
-    uint32_t prevWakeTime = osKernelSysTick();
+void readOxidizerTankPressureTask(void const* arg) {
+  OxidizerTankPressureData* data = (OxidizerTankPressureData*)arg;
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    double vo = 0;  // The pressure sensor voltage after amplification
-    double vi = 0;  // The original pressure sensor output
-    double tankPressure = 0;
+  double vo = 0;  // The pressure sensor voltage after amplification
+  double vi = 0;  // The original pressure sensor output
+  double tankPressure = 0;
 
-    int oxidizerTankQueueIndex = 0;
+  int oxidizerTankQueueIndex = 0;
 
-    HAL_ADC_Start(&hadc2);  // Enables ADC and starts conversion of regular channels
+  HAL_ADC_Start(&hadc2);  // Enables ADC and starts conversion of regular channels
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, READ_OXIDIZER_TANK_PRESSURE_PERIOD);
+  for (;;) {
+    osDelayUntil(&prevWakeTime, READ_OXIDIZER_TANK_PRESSURE_PERIOD);
 
-        if (HAL_ADC_PollForConversion(&hadc2, OXIDIZER_TANK_POLL_TIMEOUT) == HAL_OK)
-        {
-            oxidizerTankValuesQueue[oxidizerTankQueueIndex++] = HAL_ADC_GetValue(&hadc2);
-        }
-
-        uint16_t adcRead = averageArray(oxidizerTankValuesQueue, QUEUE_SIZE);
-
-        vo = 3.3 / (pow(2, 12) - 1) * adcRead;    // Calculate voltage from the 12 bit ADC reading
-
-        // Since the voltage output of the pressure sensor is very small ( below 0.1V ), an opamp was used to amplify
-        // the voltage to be more accuractely read by the ADC. See AndromedaV2 PCB schematic for details.
-        vi = (double) (13.0 / 400.0) * vo * 1000; // Calculate the original voltage output of the sensor * 1000 to keep decimal places
-
-        // The pressure sensor is ratiometric. The pressure is 0 psi when the voltage is 0V, and is 1000
-        // psi when the voltage is 0.1V. The equation is derived from this information.
-        tankPressure = vi * 1000 / 0.1;  // Tank pressure in 1000*psi
-
-        oxidizerTankQueueIndex %= QUEUE_SIZE;
-
-        if (osMutexWait(data->mutex_, 0) != osOK)
-        {
-            continue;
-        }
-
-        data->pressure_ = (int32_t) tankPressure;
-        osMutexRelease(data->mutex_);
+    if (HAL_ADC_PollForConversion(&hadc2, OXIDIZER_TANK_POLL_TIMEOUT) == HAL_OK) {
+      oxidizerTankValuesQueue[oxidizerTankQueueIndex++] = HAL_ADC_GetValue(&hadc2);
     }
+
+    uint16_t adcRead = averageArray(oxidizerTankValuesQueue, QUEUE_SIZE);
+
+    vo = 3.3 / (pow(2, 12) - 1) * adcRead;  // Calculate voltage from the 12 bit ADC reading
+
+    // Since the voltage output of the pressure sensor is very small ( below 0.1V ), an opamp was used to amplify
+    // the voltage to be more accuractely read by the ADC. See AndromedaV2 PCB schematic for details.
+    vi = (double)(13.0 / 400.0) * vo *
+         1000;  // Calculate the original voltage output of the sensor * 1000 to keep decimal places
+
+    // The pressure sensor is ratiometric. The pressure is 0 psi when the voltage is 0V, and is 1000
+    // psi when the voltage is 0.1V. The equation is derived from this information.
+    tankPressure = vi * 1000 / 0.1;  // Tank pressure in 1000*psi
+
+    oxidizerTankQueueIndex %= QUEUE_SIZE;
+
+    if (osMutexWait(data->mutex_, 0) != osOK) {
+      continue;
+    }
+
+    data->pressure_ = (int32_t)tankPressure;
+    osMutexRelease(data->mutex_);
+  }
 }

--- a/Core/Src/TransmitData.c
+++ b/Core/Src/TransmitData.c
@@ -1,31 +1,31 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
 #include "TransmitData.h"
-#include "Utils.h"
-#include "FlightPhase.h"
-#include "Data.h"
-#include "LogData.h"
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
+#include "Data.h"
+#include "FlightPhase.h"
+#include "LogData.h"
+#include "Utils.h"
+#include "cmsis_os.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
 
 static const int TRANSMIT_DATA_PERIOD = 200;
 
 static const int8_t IMU_HEADER_BYTE = 0x10;
 static const int8_t BAROMETER_HEADER_BYTE = 0x11;
 static const int8_t GPS_HEADER_BYTE = 0x12;
-static const int8_t OXIDIZER_TANK_HEADER_BYTE = 0x34; 			// not used
-static const int8_t COMBUSTION_CHAMBER_HEADER_BYTE = 0x35;		// not used
+static const int8_t OXIDIZER_TANK_HEADER_BYTE = 0x34;       // not used
+static const int8_t COMBUSTION_CHAMBER_HEADER_BYTE = 0x35;  // not used
 static const int8_t FLIGHT_PHASE_HEADER_BYTE = 0x13;
-static const int8_t INJECTION_VALVE_STATUS_HEADER_BYTE = 0x38; 	// not used
-static const int8_t LOWER_VALVE_STATUS_HEADER_BYTE = 0x39;		// not used
+static const int8_t INJECTION_VALVE_STATUS_HEADER_BYTE = 0x38;  // not used
+static const int8_t LOWER_VALVE_STATUS_HEADER_BYTE = 0x39;      // not used
 static const int8_t BATTERY_VOLTAGE_HEADER_BYTE = 0x14;
 static const int8_t TICK_HEADER_BYTE = 0x15;
 static const int8_t LOG_STATUS_BYTE = 0x16;
-static const int8_t CRC_HEADER_BYTE = 0x17;						// needed?
+static const int8_t CRC_HEADER_BYTE = 0x17;  // needed?
 
 #define F0_ESCAPE (0xF0)
 #define START_FLAG (0x00)
@@ -33,93 +33,90 @@ static const int8_t CRC_HEADER_BYTE = 0x17;						// needed?
 
 static const uint8_t UART_TIMEOUT = 100;
 
-void transmitLogEntry(LogEntry* givenLog)
-{
-	int16_t bufferIndex = 0;
-    uint8_t* transmitBuffer = pvPortMalloc( sizeof(LogEntry)*3 );
+void transmitLogEntry(LogEntry* givenLog) {
+  int16_t bufferIndex = 0;
+  uint8_t* transmitBuffer = pvPortMalloc(sizeof(LogEntry) * 3);
 
-    // start flag	0xF000
-	transmitBuffer[bufferIndex++] = F0_ESCAPE;
-    transmitBuffer[bufferIndex++] = START_FLAG;
+  // start flag	0xF000
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = START_FLAG;
 
-    // IMU flag 	0xF010
-    transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = IMU_HEADER_BYTE;
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->accelX);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->accelY);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->accelZ);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gyroX);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gyroY);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gyroZ);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->magnetoX);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->magnetoY);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->magnetoZ);
+  // IMU flag 	0xF010
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = IMU_HEADER_BYTE;
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->accelX);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->accelY);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->accelZ);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gyroX);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gyroY);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gyroZ);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->magnetoX);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->magnetoY);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->magnetoZ);
 
-    // Baro flag 	0xF011
-    transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = BAROMETER_HEADER_BYTE;
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->barometerPressure);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->barometerTemperature);
+  // Baro flag 	0xF011
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = BAROMETER_HEADER_BYTE;
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->barometerPressure);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->barometerTemperature);
 
-    // GPS flag 	0xF012
-    transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = GPS_HEADER_BYTE;
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gps_time);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->latitude_degrees);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->latitude_minutes);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->longitude_degrees);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->longitude_minutes);
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->altitude);
+  // GPS flag 	0xF012
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = GPS_HEADER_BYTE;
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->gps_time);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->latitude_degrees);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->latitude_minutes);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->longitude_degrees);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->longitude_minutes);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->altitude);
 
-    // flight phase flag 	0xF013
-    transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = FLIGHT_PHASE_HEADER_BYTE;
-    bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->currentFlightPhase);
+  // flight phase flag 	0xF013
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = FLIGHT_PHASE_HEADER_BYTE;
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->currentFlightPhase);
 
-    // battery voltage flag 	0xF014
-    transmitBuffer[bufferIndex++] = F0_ESCAPE;
-    transmitBuffer[bufferIndex++] = BATTERY_VOLTAGE_HEADER_BYTE;
-    bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->batteryVoltage);
+  // battery voltage flag 	0xF014
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = BATTERY_VOLTAGE_HEADER_BYTE;
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->batteryVoltage);
 
-    // tick flag 	0xF015
-	transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = TICK_HEADER_BYTE;
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->tick);
+  // tick flag 	0xF015
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = TICK_HEADER_BYTE;
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, givenLog->tick);
 
-    // Log status flag 	0xF016
-	transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = LOG_STATUS_BYTE;
-	bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, (currentSectorAddr << 16) | (isErasing << 1) | isOkayToLog);
+  // Log status flag 	0xF016
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = LOG_STATUS_BYTE;
+  bufferIndex =
+      writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, (currentSectorAddr << 16) | (isErasing << 1) | isOkayToLog);
 
-	// CRC flag		0xF017
-    transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = CRC_HEADER_BYTE;
-    uint32_t crc = HAL_CRC_Calculate(&hcrc, (uint32_t*)transmitBuffer, bufferIndex - 1);
-    bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, crc);
+  // CRC flag		0xF017
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = CRC_HEADER_BYTE;
+  uint32_t crc = HAL_CRC_Calculate(&hcrc, (uint32_t*)transmitBuffer, bufferIndex - 1);
+  bufferIndex = writeInt32ToArrayEncoded(transmitBuffer, bufferIndex, crc);
 
-	// END flag		0xF0FF
-    transmitBuffer[bufferIndex++] = F0_ESCAPE;
-	transmitBuffer[bufferIndex++] = END_FLAG;
+  // END flag		0xF0FF
+  transmitBuffer[bufferIndex++] = F0_ESCAPE;
+  transmitBuffer[bufferIndex++] = END_FLAG;
 
-	HAL_UART_Transmit(&huart2, transmitBuffer, bufferIndex, UART_TIMEOUT);
+  HAL_UART_Transmit(&huart2, transmitBuffer, bufferIndex, UART_TIMEOUT);
 
-    vPortFree(transmitBuffer);
+  vPortFree(transmitBuffer);
 }
 
-void transmitDataTask(void const* arg)
-{
-    AllData* data = (AllData*) arg;
-    LogEntry log;
-	initializeLogEntry(&log);
+void transmitDataTask(void const* arg) {
+  AllData* data = (AllData*)arg;
+  LogEntry log;
+  initializeLogEntry(&log);
 
-    uint32_t prevWakeTime = osKernelSysTick();
+  uint32_t prevWakeTime = osKernelSysTick();
 
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, TRANSMIT_DATA_PERIOD);
-        updateLogEntry(data, &log);
-        transmitLogEntry(&log);
-        HAL_UART_Receive_IT(&huart2, launchSystemsRxBuf, GS_CMD_SZ_B);
-    }
+  for (;;) {
+    osDelayUntil(&prevWakeTime, TRANSMIT_DATA_PERIOD);
+    updateLogEntry(data, &log);
+    transmitLogEntry(&log);
+    HAL_UART_Receive_IT(&huart2, launchSystemsRxBuf, GS_CMD_SZ_B);
+  }
 }
-

--- a/Core/Src/Utils.c
+++ b/Core/Src/Utils.c
@@ -1,60 +1,55 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
 #include "Utils.h"
 
-uint16_t averageArray(uint16_t array[], int size)
-{
-    uint16_t sum = 0;
+#include "cmsis_os.h"
+#include "stm32f4xx.h"
+#include "stm32f4xx_hal_conf.h"
 
-    for (int i = 0; i < size; i++)
-    {
-        sum += array[i];
-    }
+uint16_t averageArray(uint16_t array[], int size) {
+  uint16_t sum = 0;
 
-    return (sum / size);
+  for (int i = 0; i < size; i++) {
+    sum += array[i];
+  }
+
+  return (sum / size);
 }
 
 /**
  * @brief converts an int32 to a uint8_t array
  * right shift to put bytes in LSB slots, & with 0x00ff
  */
-void writeInt32ToArray(uint8_t* array, int startIndex, int32_t value)
-{
-    array[startIndex + 0] = (value >> 24) & 0xFF;
-    array[startIndex + 1] = (value >> 16) & 0xFF;
-    array[startIndex + 2] = (value >> 8) & 0xFF;
-    array[startIndex + 3] = value & 0xFF;
+void writeInt32ToArray(uint8_t* array, int startIndex, int32_t value) {
+  array[startIndex + 0] = (value >> 24) & 0xFF;
+  array[startIndex + 1] = (value >> 16) & 0xFF;
+  array[startIndex + 2] = (value >> 8) & 0xFF;
+  array[startIndex + 3] = value & 0xFF;
 }
 
 /**
  * @brief used for transmitting encoded data
  */
 
-int writeInt32ToArrayEncoded(uint8_t* array, int startIndex, int32_t value)
-{
-	uint8_t temp;
-	uint8_t insertedCount = 0;
-	int i = 0;
+int writeInt32ToArrayEncoded(uint8_t* array, int startIndex, int32_t value) {
+  uint8_t temp;
+  uint8_t insertedCount = 0;
+  int i = 0;
 
-	while (insertedCount < 4){
-		temp = (value >> ( 24 - (insertedCount * 8)) ) & 0xFF;
+  while (insertedCount < 4) {
+    temp = (value >> (24 - (insertedCount * 8))) & 0xFF;
 
-		if (temp == 0xF0){
-			array[startIndex + i++] = 0xF0;
-			array[startIndex + i++] = 0xF1;
-		}
-		else{
-			array[startIndex + i++] = temp;
-		}
+    if (temp == 0xF0) {
+      array[startIndex + i++] = 0xF0;
+      array[startIndex + i++] = 0xF1;
+    } else {
+      array[startIndex + i++] = temp;
+    }
 
-		insertedCount ++;
-	}
+    insertedCount++;
+  }
 
-	return startIndex + i; // returns the next startIndex
+  return startIndex + i;  // returns the next startIndex
 
-	// return some sense of how many bytes were added (i ?)
+  // return some sense of how many bytes were added (i ?)
 }
 
 /**
@@ -63,12 +58,11 @@ int writeInt32ToArrayEncoded(uint8_t* array, int startIndex, int32_t value)
  * @param startIndex, where the data field starts in the array
  * @param value, pointer to the data field that should be updated
  */
-void readUInt32FromUInt8Array(uint8_t* array, int startIndex, int32_t* value)
-{
-    uint32_t temp = 0;
-    temp += (array[startIndex + 0] << 24); // eeprom reads little or big endian?
-    temp += (array[startIndex + 1] << 16);
-    temp += (array[startIndex + 2] << 8);
-    temp += (array[startIndex + 3]);
-    *value = temp;
+void readUInt32FromUInt8Array(uint8_t* array, int startIndex, int32_t* value) {
+  uint32_t temp = 0;
+  temp += (array[startIndex + 0] << 24);  // eeprom reads little or big endian?
+  temp += (array[startIndex + 1] << 16);
+  temp += (array[startIndex + 2] << 8);
+  temp += (array[startIndex + 3]);
+  *value = temp;
 }

--- a/Core/Src/ValveControl.c
+++ b/Core/Src/ValveControl.c
@@ -1,36 +1,34 @@
+#include "ValveControl.h"
+
+#include "cmsis_os.h"
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "ValveControl.h"
 
 int injectionValveIsOpen = 0;
 int lowerVentValveIsOpen = 0;
 
 // Injection Valve is Normally Closed (NC)
-void openInjectionValve()
-{
-    // Powered is open
-    HAL_GPIO_WritePin(INJECTION_VALVE_GPIO_Port, INJECTION_VALVE_Pin, GPIO_PIN_SET);
-    injectionValveIsOpen = 1;
+void openInjectionValve() {
+  // Powered is open
+  HAL_GPIO_WritePin(INJECTION_VALVE_GPIO_Port, INJECTION_VALVE_Pin, GPIO_PIN_SET);
+  injectionValveIsOpen = 1;
 }
 
-void closeInjectionValve()
-{
-    // Unpowered is closed
-    HAL_GPIO_WritePin(INJECTION_VALVE_GPIO_Port, INJECTION_VALVE_Pin, GPIO_PIN_RESET);
-    injectionValveIsOpen = 0;
+void closeInjectionValve() {
+  // Unpowered is closed
+  HAL_GPIO_WritePin(INJECTION_VALVE_GPIO_Port, INJECTION_VALVE_Pin, GPIO_PIN_RESET);
+  injectionValveIsOpen = 0;
 }
 
 // Lower vent valve is Normally Open (NO)
-void openLowerVentValve()
-{
-    HAL_GPIO_WritePin(LOWER_VENT_VALVE_GPIO_Port, LOWER_VENT_VALVE_Pin, GPIO_PIN_RESET);      //Temporary pin until we change to using new board
-    lowerVentValveIsOpen = 1;
+void openLowerVentValve() {
+  HAL_GPIO_WritePin(LOWER_VENT_VALVE_GPIO_Port, LOWER_VENT_VALVE_Pin,
+                    GPIO_PIN_RESET);  // Temporary pin until we change to using new board
+  lowerVentValveIsOpen = 1;
 }
 
-void closeLowerVentValve()
-{
-    HAL_GPIO_WritePin(LOWER_VENT_VALVE_GPIO_Port, LOWER_VENT_VALVE_Pin, GPIO_PIN_SET);    //Temporary pin until we change to using new board
-    lowerVentValveIsOpen = 0;
+void closeLowerVentValve() {
+  HAL_GPIO_WritePin(LOWER_VENT_VALVE_GPIO_Port, LOWER_VENT_VALVE_Pin,
+                    GPIO_PIN_SET);  // Temporary pin until we change to using new board
+  lowerVentValveIsOpen = 0;
 }

--- a/SOAR_format_prefs.xml
+++ b/SOAR_format_prefs.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="1">
+    <profile kind="CodeFormatterProfile" name="SOAR" version="1">
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_exception_specification" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_pointer_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.format_header_comment" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_structured_binding_name_list" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_base_clause" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_linkage_declaration" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_conditional_expression" value="34"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_structured_binding_name_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_pointer_in_declarator_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_expression_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_base_clause" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_base_types" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.comment.line_up_line_comment_in_blocks_on_first_column" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_body_declarations_compare_to_namespace_header" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_access_specifier_extra_spaces" value="0"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_lambda_return" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.comment.never_indent_line_comments_on_first_column" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_expression_list" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_bracket" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_base_clause_in_type_declaration" value="80"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_angle_bracket_in_template_parameters" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_member_access" value="0"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_after_colon_in_constructor_initializer_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_namespace_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_parameters_in_method_declaration" value="18"/>
+        <setting id="org.eclipse.cdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.comment_formatter_off_tag" value="clang-format off"/>
+        <setting id="org.eclipse.cdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_brackets" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_angle_bracket_in_template_arguments" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_bracket" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_angle_bracket_in_template_arguments" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_template_arguments" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_declarator_list" value="16"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_between_empty_parens_in_exception_specification" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_lambda_expression" value="20"/>
+        <setting id="org.eclipse.cdt.core.formatter.comment.min_distance_between_code_and_line_comment" value="2"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_bracket" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_constructor_initializer_list" value="0"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_exception_specification" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_declarator_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.format_line_comment" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_angle_bracket_in_template_parameters" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.format_block_comment" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_angle_bracket_in_template_parameters" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_overloaded_left_shift_chain" value="16"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_identifier_in_function_declaration" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.comment_formatter_on_tag" value="clang-format on"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_body_declarations_compare_to_linkage" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_lambda_return" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_after_label" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_declarator_list" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_brace_in_namespace_declaration" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_access_specifier_compare_to_type_header" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_template_parameters" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_pointer_in_declarator_list" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_conditional_expression_chain" value="18"/>
+        <setting id="org.eclipse.cdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_after_template_declaration" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_ref_qualifier_in_structured_binding" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_colon_in_constructor_initializer_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.keep_imple_if_on_one_line" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_structured_binding_name_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_structured_binding_name_list" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.indentation.size" value="2"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_angle_bracket_in_template_parameters" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_expression_list" value="0"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_base_types" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_label_compare_to_statements" value="false"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_declaration_compare_to_template_header" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.use_comment_formatter_tag" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_angle_bracket_in_template_arguments" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_arguments_in_method_invocation" value="18"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_exception_specification" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.join_wrapped_lines" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_assignment" value="16"/>
+        <setting id="org.eclipse.cdt.core.formatter.brace_position_for_linkage_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_comma_in_template_arguments" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_angle_bracket_in_template_arguments" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_comma_in_template_parameters" value="do not insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.indent_body_declarations_compare_to_access_specifier" value="true"/>
+        <setting id="org.eclipse.cdt.core.formatter.alignment_for_enumerator_list" value="48"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_structured_binding_name_list" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_pointer_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.cdt.core.formatter.tabulation.size" value="2"/>
+        <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+    </profile>
+</profiles>

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,1 @@
+clang-format -i $(find Core/Inc/ Core/Src/ -type f -not -iregex "Core/\(Src\|Inc\)/\(stm32\|syscalls\|sysmem\|system_stm32\|freertos\).*")


### PR DESCRIPTION
Integrates clang-format in order to standardize code formatting. Includes a script to run, which formats only `.c` and `.h` files we have written, as well as `main.c`. **CLANG-FORMAT MUST BE INSTALLED LOCALLY! DOWNLOAD AND INSTALL LLVM: https://llvm.org/builds/**