### PR TITLE
Solid Flight Phases and Global Header

### DIFF
--- a/Core/Inc/AbortPhase.h
+++ b/Core/Inc/AbortPhase.h
@@ -1,13 +1,13 @@
-#pragma once
-
-#define ABORT_VALVE_PULSE_MAX_TIME (8000)
-
-extern uint8_t launchCmdReceived;
-extern uint8_t systemIsArmed;
-extern uint8_t pulseVentValveRequested;
-extern uint8_t abortCmdReceived;
-extern uint8_t resetAvionicsCmdReceived;
-const extern int32_t HEARTBEAT_TIMEOUT;
-extern int32_t heartbeatTimer;
-
-void abortPhaseTask(void const* arg);
+//#pragma once
+//
+//#define ABORT_VALVE_PULSE_MAX_TIME (8000)
+//
+//extern uint8_t launchCmdReceived;
+//extern uint8_t systemIsArmed;
+//extern uint8_t pulseVentValveRequested;
+//extern uint8_t abortCmdReceived;
+//extern uint8_t resetAvionicsCmdReceived;
+//const extern int32_t HEARTBEAT_TIMEOUT;
+//extern int32_t heartbeatTimer;
+//
+//void abortPhaseTask(void const* arg);

--- a/Core/Inc/Debug.h
+++ b/Core/Inc/Debug.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "main.h"
+#include "Globals.h"
 
-extern UART_HandleTypeDef huart5;
+extern UART_HandleTypeDef DEBUG_UART;
 
 void debugTask(void const* arg);

--- a/Core/Inc/EngineControl.h
+++ b/Core/Inc/EngineControl.h
@@ -1,8 +1,8 @@
-#pragma once
-
-extern UART_HandleTypeDef huart1;
-extern uint8_t launchCmdReceived;
-extern uint8_t systemIsArmed;
-extern uint8_t pulseVentValveRequested;
-
-void engineControlTask(void const* arg);
+//#pragma once
+//
+//extern UART_HandleTypeDef huart1;
+//extern uint8_t launchCmdReceived;
+//extern uint8_t systemIsArmed;
+//extern uint8_t pulseVentValveRequested;
+//
+//void engineControlTask(void const* arg);

--- a/Core/Inc/FlightPhase.h
+++ b/Core/Inc/FlightPhase.h
@@ -2,9 +2,10 @@
 
 #include "stm32f4xx_hal.h"
 #include "cmsis_os.h"
+#include "Globals.h"
 
-extern UART_HandleTypeDef huart2;
-extern UART_HandleTypeDef huart5;
+extern UART_HandleTypeDef GS_UART;
+extern UART_HandleTypeDef DEBUG_UART;
 extern uint8_t groundSystemsRxChar;
 extern osMutexId flightPhaseMutex;
 

--- a/Core/Inc/FlightPhase.h
+++ b/Core/Inc/FlightPhase.h
@@ -3,14 +3,25 @@
 #include "stm32f4xx_hal.h"
 #include "cmsis_os.h"
 
-#define IS_ABORT_PHASE ( \
-            getCurrentFlightPhase() == ABORT_COMMAND_RECEIVED || \
-            getCurrentFlightPhase() == ABORT_COMMUNICATION_ERROR || \
-            getCurrentFlightPhase() == ABORT_OXIDIZER_PRESSURE || \
-            getCurrentFlightPhase() == ABORT_UNSPECIFIED_REASON \
-        )
+extern UART_HandleTypeDef huart2;
+extern UART_HandleTypeDef huart5;
+extern uint8_t groundSystemsRxChar;
+extern osMutexId flightPhaseMutex;
 
-extern osMutexId flightPhaseMutex; // ONLY PUBLIC FOR INITIALIZATION PURPOSES
+#define CLEAR_FLASH_CMD_BYTE 0x1F
+#define LAUNCH_CMD_BYTE 0x20
+#define ARM_CMD_BYTE 0x21
+#define ABORT_CMD_BYTE 0x2F
+#define RESET_CMD_BYTE 0x4F
+#define HEARTBEAT_BYTE 0x46
+#define OPEN_INJECTION_VALVE 0x2A
+#define CLOSE_INJECTION_VALVE 0x2B
+#define FLIGHT_PHASE_CHECK_PERIOD (1000)
+#define BURN_TO_COST_TIME (5550) //5.55s
+#define COAST_TO_POST_TIME (10 * 60 * 1000) // 10 min
+#define HEARTBEAT_COUNTDOWN (3 * 60 * 1000) // 3 min
+#define LAUNCH_COUNT (3)
+
 
 typedef enum
 {
@@ -22,12 +33,38 @@ typedef enum
     MAIN_DESCENT,
     POST_FLIGHT,
     ABORT_COMMAND_RECEIVED,
+	ABORT_NO_HEARTBEAT,
     ABORT_COMMUNICATION_ERROR,
     ABORT_OXIDIZER_PRESSURE,
     ABORT_UNSPECIFIED_REASON
 } FlightPhase;
 
+/*
+ * Switches to the new flight phase specified by newPhase
+ */
 void newFlightPhase(FlightPhase newPhase);
+
+/*
+ * Returns the current flight phase
+ */
 FlightPhase getCurrentFlightPhase();
+
+/*
+ * Resets flight phase to PRELAUNCH
+ */
 void resetFlightPhase();
 
+/*
+ * Check if current flight phase is in one of the abort phases
+ */
+int isAbortPhase();
+
+/*
+ * Thread task to handle commands received from Ground Systems accumulated in flightPhaseQueue
+ */
+void flightPhaseTask(void const* flightPhaseQueue);
+
+/*
+ * Thread task to receive commands from Ground Systems via ESP UART
+ */
+void gsListenerTask(void const* arg);

--- a/Core/Inc/Globals.h
+++ b/Core/Inc/Globals.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ROCKET_TYPE_SOLID
+#define ROCKET_TYPE_SOLID
+#endif
+
 /* Structs containing data primitives */
 
 /*

--- a/Core/Inc/Globals.h
+++ b/Core/Inc/Globals.h
@@ -4,6 +4,19 @@
 #define ROCKET_TYPE_SOLID
 #endif
 
+/*
+ * Global macros for peripherals to avoid confusion over which peripheral
+ * number corresponds to what hardware.
+ */
+#define GS_UART huart1
+#define RADIO_UART huart2
+#define GPS_UART huart4
+#define DEBUG_UART huart5
+#define IMU_SPI hspi1
+#define BARO_SPI hspi3
+#define COMBINED_ADC hadc1 //Combination of Combustion chamber, oxidizer tank and propulsion valve adc
+#define BATT_ADC hadc2
+
 /* Structs containing data primitives */
 
 /*

--- a/Core/Inc/LogData.h
+++ b/Core/Inc/LogData.h
@@ -3,6 +3,5 @@
 #include "main.h"
 
 extern I2C_HandleTypeDef hi2c1;
-extern UART_HandleTypeDef huart5;
 
 void logDataTask(void const* arg);

--- a/Core/Inc/MonitorForEmergencyShutoff.h
+++ b/Core/Inc/MonitorForEmergencyShutoff.h
@@ -1,9 +1,9 @@
-#pragma once
-
-extern uint8_t abortCmdReceived;
-const extern int32_t HEARTBEAT_TIMEOUT;
-extern int32_t heartbeatTimer;
-
-void monitorForEmergencyShutoffTask(void const* arg);
-int prelaunchChecks();
-int postArmChecks();
+//#pragma once
+//
+//extern uint8_t abortCmdReceived;
+//const extern int32_t HEARTBEAT_TIMEOUT;
+//extern int32_t heartbeatTimer;
+//
+//void monitorForEmergencyShutoffTask(void const* arg);
+//int prelaunchChecks();
+//int postArmChecks();

--- a/Core/Inc/ParachutesControl.h
+++ b/Core/Inc/ParachutesControl.h
@@ -1,7 +1,7 @@
-#pragma once
-
-#include "main.h"
-
-extern int32_t counter;
-
-void parachutesControlTask(void const* arg);
+//#pragma once
+//
+//#include "main.h"
+//
+//extern int32_t counter;
+//
+//void parachutesControlTask(void const* arg);

--- a/Core/Inc/ReadAccelGyroMagnetism.h
+++ b/Core/Inc/ReadAccelGyroMagnetism.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "main.h"
+#include "Globals.h"
 
-extern SPI_HandleTypeDef hspi1;
+extern SPI_HandleTypeDef IMU_SPI;
 
 void readAccelGyroMagnetismTask(void const* arg);

--- a/Core/Inc/ReadBarometer.h
+++ b/Core/Inc/ReadBarometer.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "main.h"
+#include "Globals.h"
 
-extern SPI_HandleTypeDef hspi3;
+extern SPI_HandleTypeDef BARO_SPI;
 
 void readBarometerTask(void const* arg);
 

--- a/Core/Inc/ReadCombustionChamberPressure.h
+++ b/Core/Inc/ReadCombustionChamberPressure.h
@@ -1,5 +1,6 @@
 #pragma once
+#include "Globals.h"
 
-extern ADC_HandleTypeDef hadc1;
+extern ADC_HandleTypeDef COMBINED_ADC;
 
 void readCombustionChamberPressureTask(void const* arg);

--- a/Core/Inc/ReadGps.h
+++ b/Core/Inc/ReadGps.h
@@ -1,9 +1,9 @@
 #pragma once
-#include <Globals.h>
+#include "Globals.h"
 
 void readGpsTask(void const* arg);
 
-extern UART_HandleTypeDef huart4;
+extern UART_HandleTypeDef GPS_UART;
 
 extern char dma_rx_buffer[NMEA_MAX_LENGTH + 1];
 extern GpsData* gpsData;

--- a/Core/Inc/ReadGps.h
+++ b/Core/Inc/ReadGps.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Data.h"
+#include <Globals.h>
 
 void readGpsTask(void const* arg);
 

--- a/Core/Inc/ReadOxidizerTankPressure.h
+++ b/Core/Inc/ReadOxidizerTankPressure.h
@@ -1,5 +1,6 @@
 #pragma once
+#include "Globals.h"
 
-extern ADC_HandleTypeDef hadc2;
+extern ADC_HandleTypeDef COMBINED_ADC;
 
 void readOxidizerTankPressureTask(void const* arg);

--- a/Core/Inc/TransmitData.h
+++ b/Core/Inc/TransmitData.h
@@ -7,4 +7,3 @@ extern UART_HandleTypeDef huart1;
 extern CRC_HandleTypeDef hcrc;
 extern int injectionValveIsOpen;
 extern int lowerVentValveIsOpen;
-extern uint8_t launchSystemsRxChar;

--- a/Core/Inc/TransmitData.h
+++ b/Core/Inc/TransmitData.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "Globals.h"
+
 void transmitDataTask(void const* arg);
 
-extern UART_HandleTypeDef huart2;
-extern UART_HandleTypeDef huart1;
+extern UART_HandleTypeDef RADIO_UART;
+extern UART_HandleTypeDef GS_UART;
 extern CRC_HandleTypeDef hcrc;
 extern int injectionValveIsOpen;
 extern int lowerVentValveIsOpen;

--- a/Core/Src/AbortPhase.c
+++ b/Core/Src/AbortPhase.c
@@ -1,41 +1,41 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "AbortPhase.h"
-#include "FlightPhase.h"
-#include "ValveControl.h"
-
-static const int ABORT_PHASE_TASK_PERIOD = 100;
-
-void abortPhaseTask(void const* arg)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, ABORT_PHASE_TASK_PERIOD);
-
-        if (!isAbortPhase())
-        {
-            // Do nothing if not in abort
-            resetAvionicsCmdReceived = 0;
-        }
-        else
-        {
-            openLowerVentValve();
-
-            // Detect a reset
-            if (resetAvionicsCmdReceived)
-            {
-                // Reset global variables
-                closeLowerVentValve();
-                launchCmdReceived = 0;
-                abortCmdReceived = 0;
-                resetAvionicsCmdReceived = 0;
-                heartbeatTimer = HEARTBEAT_TIMEOUT;
-                resetFlightPhase();
-            }
-        }
-    }
-}
+//#include "stm32f4xx.h"
+//#include "stm32f4xx_hal_conf.h"
+//#include "cmsis_os.h"
+//
+//#include "AbortPhase.h"
+//#include "FlightPhase.h"
+//#include "ValveControl.h"
+//
+//static const int ABORT_PHASE_TASK_PERIOD = 100;
+//
+//void abortPhaseTask(void const* arg)
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, ABORT_PHASE_TASK_PERIOD);
+//
+//        if (!isAbortPhase())
+//        {
+//            // Do nothing if not in abort
+//            resetAvionicsCmdReceived = 0;
+//        }
+//        else
+//        {
+//            openLowerVentValve();
+//
+//            // Detect a reset
+//            if (resetAvionicsCmdReceived)
+//            {
+//                // Reset global variables
+//                closeLowerVentValve();
+//                launchCmdReceived = 0;
+//                abortCmdReceived = 0;
+//                resetAvionicsCmdReceived = 0;
+//                heartbeatTimer = HEARTBEAT_TIMEOUT;
+//                resetFlightPhase();
+//            }
+//        }
+//    }
+//}

--- a/Core/Src/AbortPhase.c
+++ b/Core/Src/AbortPhase.c
@@ -16,7 +16,7 @@ void abortPhaseTask(void const* arg)
     {
         osDelayUntil(&prevWakeTime, ABORT_PHASE_TASK_PERIOD);
 
-        if (!IS_ABORT_PHASE)
+        if (!isAbortPhase())
         {
             // Do nothing if not in abort
             resetAvionicsCmdReceived = 0;

--- a/Core/Src/Debug.c
+++ b/Core/Src/Debug.c
@@ -33,7 +33,7 @@ void debugTask(void const* arg) {
 	while (1) {
 		osDelayUntil(&prevWakeTime, DEBUG_TASK_PERIOD);
 
-		HAL_UART_Receive(&huart5, &buffer, 1, 1000);
+		HAL_UART_Receive(&DEBUG_UART, &buffer, 1, 1000);
 
 		// LOGIC
 	}

--- a/Core/Src/EngineControl.c
+++ b/Core/Src/EngineControl.c
@@ -4,8 +4,8 @@
 
 #include "EngineControl.h"
 #include "FlightPhase.h"
-#include "Data.h"
 #include "ValveControl.h"
+#include "Globals.h"
 
 static const int PRELAUNCH_PHASE_PERIOD = 50;
 static const int BURN_DURATION = 8500;

--- a/Core/Src/EngineControl.c
+++ b/Core/Src/EngineControl.c
@@ -1,172 +1,172 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "EngineControl.h"
-#include "FlightPhase.h"
-#include "ValveControl.h"
-#include "Globals.h"
-
-static const int PRELAUNCH_PHASE_PERIOD = 50;
-static const int BURN_DURATION = 8500;
-static const int POST_BURN_PERIOD = 1000;
-
-static const int POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION = 10 * 60 * 1000; // 10 minutes
-
-/**
- * This routine keeps the injection valve closed during prelaunch.
- * This routine exits when the current flight phase is no longer PRELAUNCH.
- */
-void engineControlPrelaunchRoutine(OxidizerTankPressureData* data)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-
-    closeInjectionValve();
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, PRELAUNCH_PHASE_PERIOD);
-
-        closeInjectionValve();
-        closeLowerVentValve();
-
-        int32_t oxidizerTankPressure = -1;
-
-        // if (osMutexWait(data->mutex_, 0) == osOK)
-        // {
-        //     // read tank pressure
-        //     oxidizerTankPressure = data->pressure_;
-        //     osMutexRelease(data->mutex_);
-
-        //     if (oxidizerTankPressure >= 850 * 1000)
-        //     {
-        //         newFlightPhase(ABORT_OXIDIZER_PRESSURE);
-        //     }
-        // }
-
-        if (launchCmdReceived >= 2 && ARM == getCurrentFlightPhase())
-        {
-            newFlightPhase(BURN);
-        }
-
-        if (PRELAUNCH != getCurrentFlightPhase() && ARM != getCurrentFlightPhase())
-        {
-            return;
-        }
-    }
-}
-
-/**
- * This routine opens the injection valve for the burn phase
- * for a preconfigured amount of time. Once the preconfigured amount
- * of time has passed, this routine updates the current flight phase.
- */
-void engineControlBurnRoutine()
-{
-    closeLowerVentValve();
-    openInjectionValve();
-    osDelay(BURN_DURATION);
-    newFlightPhase(COAST);
-    return;
-}
-
-/**
- * This routine closes all valves and changes to the PostFlightRoutine
- * after 10 mins passed since COAST started.
- */
-void engineControlPostBurnRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t timeInPostBurn = 0;
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
-        FlightPhase phase = getCurrentFlightPhase();
-
-        if (phase != COAST && phase != DROGUE_DESCENT && phase != MAIN_DESCENT)
-        {
-            return;
-        }
-
-        // requires 49 days to overflow, not handling this case
-        timeInPostBurn += POST_BURN_PERIOD;
-
-        if (timeInPostBurn < POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION)
-        {
-            closeInjectionValve();
-            closeLowerVentValve();
-        }
-        else
-        {
-            newFlightPhase(POST_FLIGHT);
-        }
-    }
-}
-
-/**
- * This routine is the final phase.
- */
-void engineControlPostFlightRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t timeInPostBurn = 0;
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
-        FlightPhase phase = getCurrentFlightPhase();
-
-        if (phase != POST_FLIGHT)
-        {
-            return;
-        }
-
-        closeInjectionValve();
-        openLowerVentValve();
-    }
-}
-
-void engineControlTask(void const* arg)
-{
-    OxidizerTankPressureData* data = (OxidizerTankPressureData*) arg;
-
-    for (;;)
-    {
-        switch (getCurrentFlightPhase())
-        {
-            case PRELAUNCH:
-            case ARM:
-                engineControlPrelaunchRoutine(data);
-                break;
-
-            case BURN:
-                engineControlBurnRoutine();
-                break;
-
-            case COAST:  // fall through
-            case DROGUE_DESCENT:
-            case MAIN_DESCENT:
-                engineControlPostBurnRoutine();
-                break;
-
-            case POST_FLIGHT:
-                engineControlPostFlightRoutine();
-                break;
-
-            // All aborts fall through here because they all do the same thing in each case
-            case ABORT_COMMAND_RECEIVED:
-            case ABORT_OXIDIZER_PRESSURE:
-            case ABORT_UNSPECIFIED_REASON:
-            case ABORT_COMMUNICATION_ERROR:
-
-                // Do nothing and let other code do what needs to be done
-                osDelay(PRELAUNCH_PHASE_PERIOD);
-
-                break;
-
-            default:
-                break;
-        }
-    }
-}
+//#include "stm32f4xx.h"
+//#include "stm32f4xx_hal_conf.h"
+//#include "cmsis_os.h"
+//
+//#include "EngineControl.h"
+//#include "FlightPhase.h"
+//#include "ValveControl.h"
+//#include "Globals.h"
+//
+//static const int PRELAUNCH_PHASE_PERIOD = 50;
+//static const int BURN_DURATION = 8500;
+//static const int POST_BURN_PERIOD = 1000;
+//
+//static const int POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION = 10 * 60 * 1000; // 10 minutes
+//
+///**
+// * This routine keeps the injection valve closed during prelaunch.
+// * This routine exits when the current flight phase is no longer PRELAUNCH.
+// */
+//void engineControlPrelaunchRoutine(OxidizerTankPressureData* data)
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//
+//    closeInjectionValve();
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, PRELAUNCH_PHASE_PERIOD);
+//
+//        closeInjectionValve();
+//        closeLowerVentValve();
+//
+//        int32_t oxidizerTankPressure = -1;
+//
+//        // if (osMutexWait(data->mutex_, 0) == osOK)
+//        // {
+//        //     // read tank pressure
+//        //     oxidizerTankPressure = data->pressure_;
+//        //     osMutexRelease(data->mutex_);
+//
+//        //     if (oxidizerTankPressure >= 850 * 1000)
+//        //     {
+//        //         newFlightPhase(ABORT_OXIDIZER_PRESSURE);
+//        //     }
+//        // }
+//
+//        if (launchCmdReceived >= 2 && ARM == getCurrentFlightPhase())
+//        {
+//            newFlightPhase(BURN);
+//        }
+//
+//        if (PRELAUNCH != getCurrentFlightPhase() && ARM != getCurrentFlightPhase())
+//        {
+//            return;
+//        }
+//    }
+//}
+//
+///**
+// * This routine opens the injection valve for the burn phase
+// * for a preconfigured amount of time. Once the preconfigured amount
+// * of time has passed, this routine updates the current flight phase.
+// */
+//void engineControlBurnRoutine()
+//{
+//    closeLowerVentValve();
+//    openInjectionValve();
+//    osDelay(BURN_DURATION);
+//    newFlightPhase(COAST);
+//    return;
+//}
+//
+///**
+// * This routine closes all valves and changes to the PostFlightRoutine
+// * after 10 mins passed since COAST started.
+// */
+//void engineControlPostBurnRoutine()
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//    uint32_t timeInPostBurn = 0;
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
+//        FlightPhase phase = getCurrentFlightPhase();
+//
+//        if (phase != COAST && phase != DROGUE_DESCENT && phase != MAIN_DESCENT)
+//        {
+//            return;
+//        }
+//
+//        // requires 49 days to overflow, not handling this case
+//        timeInPostBurn += POST_BURN_PERIOD;
+//
+//        if (timeInPostBurn < POST_BURN_REOPEN_LOWER_VENT_VALVE_DURATION)
+//        {
+//            closeInjectionValve();
+//            closeLowerVentValve();
+//        }
+//        else
+//        {
+//            newFlightPhase(POST_FLIGHT);
+//        }
+//    }
+//}
+//
+///**
+// * This routine is the final phase.
+// */
+//void engineControlPostFlightRoutine()
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//    uint32_t timeInPostBurn = 0;
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, POST_BURN_PERIOD);
+//        FlightPhase phase = getCurrentFlightPhase();
+//
+//        if (phase != POST_FLIGHT)
+//        {
+//            return;
+//        }
+//
+//        closeInjectionValve();
+//        openLowerVentValve();
+//    }
+//}
+//
+//void engineControlTask(void const* arg)
+//{
+//    OxidizerTankPressureData* data = (OxidizerTankPressureData*) arg;
+//
+//    for (;;)
+//    {
+//        switch (getCurrentFlightPhase())
+//        {
+//            case PRELAUNCH:
+//            case ARM:
+//                engineControlPrelaunchRoutine(data);
+//                break;
+//
+//            case BURN:
+//                engineControlBurnRoutine();
+//                break;
+//
+//            case COAST:  // fall through
+//            case DROGUE_DESCENT:
+//            case MAIN_DESCENT:
+//                engineControlPostBurnRoutine();
+//                break;
+//
+//            case POST_FLIGHT:
+//                engineControlPostFlightRoutine();
+//                break;
+//
+//            // All aborts fall through here because they all do the same thing in each case
+//            case ABORT_COMMAND_RECEIVED:
+//            case ABORT_OXIDIZER_PRESSURE:
+//            case ABORT_UNSPECIFIED_REASON:
+//            case ABORT_COMMUNICATION_ERROR:
+//
+//                // Do nothing and let other code do what needs to be done
+//                osDelay(PRELAUNCH_PHASE_PERIOD);
+//
+//                break;
+//
+//            default:
+//                break;
+//        }
+//    }
+//}

--- a/Core/Src/FlightPhase.c
+++ b/Core/Src/FlightPhase.c
@@ -88,7 +88,7 @@ int isAbortPhase()
 
 void gsListenerTask(void const* arg)
 {
-	HAL_UART_Receive_IT(&huart2, &groundSystemsRxChar, 1);
+	HAL_UART_Receive_IT(&GS_UART, &groundSystemsRxChar, 1);
 }
 
 void flightPhaseTask(void const* flightPhaseQueue)
@@ -107,11 +107,11 @@ void flightPhaseTask(void const* flightPhaseQueue)
 		 */
 //		if (xQueueReceive(flightPhaseQueue, &cmd, 0) != pdTRUE)
 //		{
-//			HAL_UART_Transmit(&huart5, (uint8_t *)"Error in Receiving from Queue\n\n", 31, 1000);
+//			HAL_UART_Transmit(&DEBUG_UART, (uint8_t *)"Error in Receiving from Queue\n\n", 31, 1000);
 //		}
 //		else
 //		{
-//			HAL_UART_Transmit(&huart5, &cmd, sizeof(uint8_t), 1000);
+//			HAL_UART_Transmit(&DEBUG_UART, &cmd, sizeof(uint8_t), 1000);
 //		}
 		// Check heart beat, if no heart beat, go into abort
 		if(heartbeatTimer <= 0 && currPhase != ABORT_NO_HEARTBEAT)

--- a/Core/Src/FlightPhase.c
+++ b/Core/Src/FlightPhase.c
@@ -70,3 +70,139 @@ void resetFlightPhase()
     currentFlightPhase = PRELAUNCH;
     return;
 }
+
+int isAbortPhase()
+{
+	FlightPhase currPhase = getCurrentFlightPhase();
+	if(currPhase == ABORT_COMMAND_RECEIVED ||
+			currPhase == ABORT_NO_HEARTBEAT ||
+			currPhase == ABORT_COMMUNICATION_ERROR ||
+			currPhase == ABORT_OXIDIZER_PRESSURE ||
+			currPhase == ABORT_UNSPECIFIED_REASON
+			)
+	{
+		return 1;
+	}
+	return 0;
+}
+
+void gsListenerTask(void const* arg)
+{
+	HAL_UART_Receive_IT(&huart2, &groundSystemsRxChar, 1);
+}
+
+void flightPhaseTask(void const* flightPhaseQueue)
+{
+	uint8_t cmd = 0;
+	int heartbeatTimer = HEARTBEAT_COUNTDOWN;
+	int launchCounter = 0;
+	int burnTimer = BURN_TO_COST_TIME;
+	int coastTimer = COAST_TO_POST_TIME;
+	for(;;)
+	{
+		uint32_t prevWakeTime = osKernelSysTick();
+		FlightPhase currPhase = getCurrentFlightPhase();
+		/*
+		 * Uncomment section to test with Debug UART
+		 */
+//		if (xQueueReceive(flightPhaseQueue, &cmd, 0) != pdTRUE)
+//		{
+//			HAL_UART_Transmit(&huart5, (uint8_t *)"Error in Receiving from Queue\n\n", 31, 1000);
+//		}
+//		else
+//		{
+//			HAL_UART_Transmit(&huart5, &cmd, sizeof(uint8_t), 1000);
+//		}
+		// Check heart beat, if no heart beat, go into abort
+		if(heartbeatTimer <= 0 && currPhase != ABORT_NO_HEARTBEAT)
+		{
+			newFlightPhase(ABORT_NO_HEARTBEAT);
+		}
+		// If in burn state, decrement burn timer, switch to coast if timer hits 0
+		else if(currPhase == BURN)
+		{
+			burnTimer -= FLIGHT_PHASE_CHECK_PERIOD;
+			if(burnTimer <= 0)
+			{
+				newFlightPhase(COAST);
+			}
+		}
+		// If in coast state, decrement coast timer, switch to post flight if timer hits 0
+		else if(currPhase == COAST)
+		{
+			coastTimer -= FLIGHT_PHASE_CHECK_PERIOD;
+			if(coastTimer <= 0)
+			{
+				newFlightPhase(POST_FLIGHT);
+			}
+		}
+		// Else we're on the ground and should carry out commands from the flightphase queue
+		else
+		{
+			// Attempt to get next command in queue, if queue is empty or error, return pdFalse with 0 delay
+			// Thus, this if block will only execute if a command is pulled out of the queue
+			if(xQueueReceive(flightPhaseQueue, &cmd, 0) == pdTRUE)
+			{
+				switch(cmd)
+				{
+					case CLEAR_FLASH_CMD_BYTE:
+					{
+						if(currPhase == PRELAUNCH)
+						{
+							// TODO: clear flash memory, either directly using SPI or setting a flag for logdata task
+						}
+						break;
+					}
+					case LAUNCH_CMD_BYTE:
+					{
+						if(currPhase == ARM)
+						{
+							launchCounter++;
+						}
+						if(launchCounter >= LAUNCH_COUNT)
+						{
+							newFlightPhase(BURN);
+						}
+						break;
+					}
+					case ARM_CMD_BYTE:
+					{
+						if(currPhase == PRELAUNCH)
+						{
+							newFlightPhase(ARM);
+						}
+						break;
+					}
+					case ABORT_CMD_BYTE:
+					{
+						newFlightPhase(ABORT_COMMAND_RECEIVED);
+						break;
+					}
+					case RESET_CMD_BYTE:
+					{
+						if(currPhase == ABORT_COMMAND_RECEIVED || currPhase == ABORT_NO_HEARTBEAT)
+						{
+							resetFlightPhase();
+							heartbeatTimer = HEARTBEAT_COUNTDOWN;
+							launchCounter = 0;
+							burnTimer = BURN_TO_COST_TIME;
+							coastTimer = COAST_TO_POST_TIME;
+						}
+						break;
+					}
+					case HEARTBEAT_BYTE:
+					{
+						heartbeatTimer = HEARTBEAT_COUNTDOWN;
+						break;
+					}
+					default:
+					{
+						break;
+					}
+				}
+			}
+			heartbeatTimer -= FLIGHT_PHASE_CHECK_PERIOD;
+		}
+		osDelayUntil(&prevWakeTime, FLIGHT_PHASE_CHECK_PERIOD);
+	}
+}

--- a/Core/Src/LogData.c
+++ b/Core/Src/LogData.c
@@ -16,9 +16,9 @@
 //#include "tm_stm32_fatfs.h"
 
 #include "LogData.h"
-#include "Data.h"
 #include "FlightPhase.h"
 #include "Utils.h"
+#include "Globals.h"
 
 /* Macros --------------------------------------------------------------------*/
 //CHECK: was max implemented somewhere else?

--- a/Core/Src/LogData.c
+++ b/Core/Src/LogData.c
@@ -18,7 +18,6 @@
 #include "LogData.h"
 #include "FlightPhase.h"
 #include "Utils.h"
-#include "Globals.h"
 
 /* Macros --------------------------------------------------------------------*/
 //CHECK: was max implemented somewhere else?

--- a/Core/Src/MonitorForEmergencyShutoff.c
+++ b/Core/Src/MonitorForEmergencyShutoff.c
@@ -4,8 +4,8 @@
 
 #include "MonitorForEmergencyShutoff.h"
 #include "FlightPhase.h"
-#include "Data.h"
 #include "ValveControl.h"
+#include "Globals.h"
 
 static const int MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD = 1000;
 

--- a/Core/Src/MonitorForEmergencyShutoff.c
+++ b/Core/Src/MonitorForEmergencyShutoff.c
@@ -1,110 +1,110 @@
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "MonitorForEmergencyShutoff.h"
-#include "FlightPhase.h"
-#include "ValveControl.h"
-#include "Globals.h"
-
-static const int MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD = 1000;
-
-void monitorForEmergencyShutoffTask(void const* arg)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-
-    // AccelGyroMagnetismData* data = (AccelGyroMagnetismData*) arg;
-    FlightPhase phase = PRELAUNCH;
-    // int32_t magnetoZ = -1;
-
-    heartbeatTimer = HEARTBEAT_TIMEOUT; // Timer counts down to 0
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD);
-
-        phase = getCurrentFlightPhase();
-
-        // if (osMutexWait(data->mutex_, 0) == osOK)
-        // {
-        //     magnetoZ = data->magnetoZ_;
-        //     osMutexRelease(data->mutex_);
-        // }
-
-        switch (getCurrentFlightPhase())
-        {
-            // Fallthrough because umbilical is still supposed to be connected during these flight phases.
-            // This means that an ABORT command can be received or a communication error could happen.
-            case PRELAUNCH:
-            case ARM:
-                heartbeatTimer -= MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD;
-
-                int prelaunchCheckStatus = prelaunchChecks();
-
-                if (prelaunchCheckStatus == 1)
-                {
-                    newFlightPhase(ABORT_COMMAND_RECEIVED);
-                }
-                else if (prelaunchCheckStatus == 2)
-                {
-                    newFlightPhase(ABORT_COMMUNICATION_ERROR);
-                }
-
-                break;
-
-            // Fallthrough because the umbilical should be disconnected during these flight phases.
-            // This means that a communication error is not a valid way to get to ABORT. The only
-            // way the ABORT command can be received is if the rocket fails to take off and the
-            // umbilical does not disconnect.
-            case BURN:
-            case COAST:
-            case DROGUE_DESCENT:
-            case MAIN_DESCENT:
-            case POST_FLIGHT:
-                if (postArmChecks())
-                {
-                    newFlightPhase(ABORT_COMMAND_RECEIVED);
-                }
-
-                // check if not right side up
-                // if ()
-                // {
-                //     newFlightPhase(ABORT);
-                // }
-                break;
-
-            default:
-                // do nothing
-                break;
-        }
-    }
-}
-
-// Return 0 for everything ok
-int prelaunchChecks()
-{
-    if (abortCmdReceived)
-    {
-        return 1;
-    }
-
-    // If heartbeatTimer reaches 0, no heartbeat was received for HEARTBEAT_TIMEOUT
-    if (heartbeatTimer <= 0)
-    {
-        return 2;
-    }
-
-    return 0;
-}
-
-// Return 0 for everything ok
-int postArmChecks()
-{
-    if (abortCmdReceived)
-    {
-        closeInjectionValve();
-        return 1;
-    }
-
-    return 0;
-}
+//#include "stm32f4xx.h"
+//#include "stm32f4xx_hal_conf.h"
+//#include "cmsis_os.h"
+//
+//#include "MonitorForEmergencyShutoff.h"
+//#include "FlightPhase.h"
+//#include "ValveControl.h"
+//#include "Globals.h"
+//
+//static const int MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD = 1000;
+//
+//void monitorForEmergencyShutoffTask(void const* arg)
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//
+//    // AccelGyroMagnetismData* data = (AccelGyroMagnetismData*) arg;
+//    FlightPhase phase = PRELAUNCH;
+//    // int32_t magnetoZ = -1;
+//
+//    heartbeatTimer = HEARTBEAT_TIMEOUT; // Timer counts down to 0
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD);
+//
+//        phase = getCurrentFlightPhase();
+//
+//        // if (osMutexWait(data->mutex_, 0) == osOK)
+//        // {
+//        //     magnetoZ = data->magnetoZ_;
+//        //     osMutexRelease(data->mutex_);
+//        // }
+//
+//        switch (getCurrentFlightPhase())
+//        {
+//            // Fallthrough because umbilical is still supposed to be connected during these flight phases.
+//            // This means that an ABORT command can be received or a communication error could happen.
+//            case PRELAUNCH:
+//            case ARM:
+//                heartbeatTimer -= MONITOR_FOR_EMERGENCY_SHUTOFF_PERIOD;
+//
+//                int prelaunchCheckStatus = prelaunchChecks();
+//
+//                if (prelaunchCheckStatus == 1)
+//                {
+//                    newFlightPhase(ABORT_COMMAND_RECEIVED);
+//                }
+//                else if (prelaunchCheckStatus == 2)
+//                {
+//                    newFlightPhase(ABORT_COMMUNICATION_ERROR);
+//                }
+//
+//                break;
+//
+//            // Fallthrough because the umbilical should be disconnected during these flight phases.
+//            // This means that a communication error is not a valid way to get to ABORT. The only
+//            // way the ABORT command can be received is if the rocket fails to take off and the
+//            // umbilical does not disconnect.
+//            case BURN:
+//            case COAST:
+//            case DROGUE_DESCENT:
+//            case MAIN_DESCENT:
+//            case POST_FLIGHT:
+//                if (postArmChecks())
+//                {
+//                    newFlightPhase(ABORT_COMMAND_RECEIVED);
+//                }
+//
+//                // check if not right side up
+//                // if ()
+//                // {
+//                //     newFlightPhase(ABORT);
+//                // }
+//                break;
+//
+//            default:
+//                // do nothing
+//                break;
+//        }
+//    }
+//}
+//
+//// Return 0 for everything ok
+//int prelaunchChecks()
+//{
+//    if (abortCmdReceived)
+//    {
+//        return 1;
+//    }
+//
+//    // If heartbeatTimer reaches 0, no heartbeat was received for HEARTBEAT_TIMEOUT
+//    if (heartbeatTimer <= 0)
+//    {
+//        return 2;
+//    }
+//
+//    return 0;
+//}
+//
+//// Return 0 for everything ok
+//int postArmChecks()
+//{
+//    if (abortCmdReceived)
+//    {
+//        closeInjectionValve();
+//        return 1;
+//    }
+//
+//    return 0;
+//}

--- a/Core/Src/ParachutesControl.c
+++ b/Core/Src/ParachutesControl.c
@@ -6,7 +6,7 @@
 
 #include "ParachutesControl.h"
 #include "FlightPhase.h"
-#include "Data.h"
+#include "Globals.h"
 
 #define SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL (1401) // metres
 

--- a/Core/Src/ParachutesControl.c
+++ b/Core/Src/ParachutesControl.c
@@ -1,395 +1,395 @@
-#include <math.h>
-
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
-#include "cmsis_os.h"
-
-#include "ParachutesControl.h"
-#include "FlightPhase.h"
-#include "Globals.h"
-
-#define SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL (1401) // metres
-
-// Pressure at spaceport america in 100*millibars on May 27, 2018
-static const int SEA_LEVEL_PRESSURE = 101421.93903699999; //TODO: THIS NEEDS TO BE UPDATED AND RECORDED ON LAUNCH DAY
-
-// Units in meters. Equivalent of 1500 ft + altitude of spaceport america.
-static const int MAIN_DEPLOYMENT_ALTITUDE = 457 + SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL;
-
-static const int MONITOR_FOR_PARACHUTES_PERIOD = 50;
-static const int KALMAN_FILTER_DROGUE_TIMEOUT = 2 * 60 * 1000; // 2 minutes
-static const int KALMAN_FILTER_MAIN_TIMEOUT = 10 * 60 * 1000; // 10 minutes
-static const int PARACHUTE_PULSE_DURATION = 2 * 1000; // 2 seconds
-static const double KALMAN_GAIN[][2] =
-{
-    {0.105553059, 0.109271566},
-    {0.0361533034, 0.0661198847},
-    {0.000273178915, 0.618030079}
-};
-
-struct KalmanStateVector
-{
-    double altitude;
-    double velocity;
-    double acceleration;
-};
-
-static struct KalmanStateVector kalmanFilterState;
-
-int32_t readAccel(AccelGyroMagnetismData* data)
-{
-    if (osMutexWait(data->mutex_, 0) != osOK)
-    {
-        return -1;
-    }
-
-    int32_t accelX = data->accelX_;
-    int32_t accelY = data->accelY_;
-    int32_t accelZ = data->accelZ_;
-    osMutexRelease(data->mutex_);
-
-    int32_t accelMagnitude =
-        sqrt(
-            accelX * accelX +
-            accelY * accelY +
-            accelZ * accelZ
-        );
-
-    return accelMagnitude;
-}
-
-int32_t readPressure(BarometerData* data)
-{
-    if (osMutexWait(data->mutex_, 0) != osOK)
-    {
-        return -1;
-    }
-
-    int32_t pressure = data->pressure_;
-    osMutexRelease(data->mutex_);
-
-    return (int32_t)pressure;
-}
-
-
-
-/**
- * Takes an old state vector and current state measurements and
- * converts them into a prediction of the rocket's current state.
- *
- * Params:
- *   oldState - (KalmanStateVector) Past altitude, velocity and acceleration
- *   currentAccel - (double) Measured acceleration
- *   currentAltitude - (double) Measured altitude
- *   dt - (double) Time since last step. In ms.
- *
- * Returns:
- *   newState - (KalmanStateVector) Current altitude, velocity and acceleration
- */
-struct KalmanStateVector filterSensors(
-    struct KalmanStateVector oldState,
-    int32_t currentAccel,
-    int32_t currentPressure,
-    double dtMillis
-)
-{
-    struct KalmanStateVector newState;
-
-    double accelIn = (double) currentAccel / 1000 * 9.8; // Milli-g -> g -> m/s
-
-    // Convert from 100*millibars to m. This may or may not be right, depending on where you look. Needs testing
-    double altIn = (double) 44307.69396 * (1 - pow(currentPressure / SEA_LEVEL_PRESSURE, 0.190284));
-
-    // Convert from ms to s
-    double dt = dtMillis / 1000;
-
-
-    // Propagate old state using simple kinematics equations
-    newState.altitude = oldState.altitude + oldState.velocity * dt + 0.5 * dt * dt * oldState.acceleration;
-    newState.velocity = oldState.velocity + oldState.acceleration * dt;
-    newState.acceleration = oldState.acceleration;
-
-    // Calculate the difference between the new state and the measurements
-    double baroDifference = altIn - newState.altitude;
-    double accelDifference = accelIn - newState.acceleration;
-
-    // Minimize the chi2 error by means of the Kalman gain matrix
-    newState.altitude = newState.altitude + KALMAN_GAIN[0][0] * baroDifference + KALMAN_GAIN[0][1] * accelDifference;
-    newState.velocity = newState.velocity + KALMAN_GAIN[1][0] * baroDifference + KALMAN_GAIN[1][1] * accelDifference;
-    newState.acceleration = newState.velocity + KALMAN_GAIN[2][0] * baroDifference + KALMAN_GAIN[2][1] * accelDifference;
-
-    return newState;
-}
-
-/**
- * Takes the current state vector and determines if apogee has been reached.
- *
- * Params:
- *   state - (KalmanStateVector) Past altitude, velocity and acceleration
- *
- * Returns:
- *   - (int32_t) 1 if apogee has been reached, 0 if not.
- */
-int32_t detectApogee(struct KalmanStateVector state)
-{
-    // Monitor for when to deploy drogue chute. Simple velocity tolerance, looking for a minimum.
-    if (state.velocity < 10)
-    {
-        return 1;
-    }
-
-    return 0;
-}
-
-/**
- * Takes the current state vector and determines if main chute should be released.
- *
- * ***NOTE: This is determined by the constant MAIN_DEPLOYMENT_ALTITUDE,
- *           which should be verified before launch.
- *
- * Params:
- *   state - (KalmanStateVector) Past altitude, velocity and acceleration
- *
- * Returns:
- *   - (int32_t) 1 if main chute should be deployed, 0 if not.
- */
-int32_t detectMainDeploymentAltitude(struct KalmanStateVector state)
-{
-    // Monitor for when to deploy main chute. Simply look for less than desired altitude.
-    if (state.altitude < MAIN_DEPLOYMENT_ALTITUDE)
-    {
-        return 1;
-    }
-
-    return 0;
-}
-
-//void ejectDrogueParachute()
+//#include <math.h>
+//
+//#include "stm32f4xx.h"
+//#include "stm32f4xx_hal_conf.h"
+//#include "cmsis_os.h"
+//
+//#include "ParachutesControl.h"
+//#include "FlightPhase.h"
+//#include "Globals.h"
+//
+//#define SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL (1401) // metres
+//
+//// Pressure at spaceport america in 100*millibars on May 27, 2018
+//static const int SEA_LEVEL_PRESSURE = 101421.93903699999; //TODO: THIS NEEDS TO BE UPDATED AND RECORDED ON LAUNCH DAY
+//
+//// Units in meters. Equivalent of 1500 ft + altitude of spaceport america.
+//static const int MAIN_DEPLOYMENT_ALTITUDE = 457 + SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL;
+//
+//static const int MONITOR_FOR_PARACHUTES_PERIOD = 50;
+//static const int KALMAN_FILTER_DROGUE_TIMEOUT = 2 * 60 * 1000; // 2 minutes
+//static const int KALMAN_FILTER_MAIN_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+//static const int PARACHUTE_PULSE_DURATION = 2 * 1000; // 2 seconds
+//static const double KALMAN_GAIN[][2] =
 //{
-//    HAL_GPIO_WritePin(DROGUE_PARACHUTE_TEMP_GPIO_Port, DROGUE_PARACHUTE_TEMP_Pin, GPIO_PIN_SET);  // high signal causes high current to ignite e-match
+//    {0.105553059, 0.109271566},
+//    {0.0361533034, 0.0661198847},
+//    {0.000273178915, 0.618030079}
+//};
+//
+//struct KalmanStateVector
+//{
+//    double altitude;
+//    double velocity;
+//    double acceleration;
+//};
+//
+//static struct KalmanStateVector kalmanFilterState;
+//
+//int32_t readAccel(AccelGyroMagnetismData* data)
+//{
+//    if (osMutexWait(data->mutex_, 0) != osOK)
+//    {
+//        return -1;
+//    }
+//
+//    int32_t accelX = data->accelX_;
+//    int32_t accelY = data->accelY_;
+//    int32_t accelZ = data->accelZ_;
+//    osMutexRelease(data->mutex_);
+//
+//    int32_t accelMagnitude =
+//        sqrt(
+//            accelX * accelX +
+//            accelY * accelY +
+//            accelZ * accelZ
+//        );
+//
+//    return accelMagnitude;
 //}
 //
-//void closeDrogueParachute()
+//int32_t readPressure(BarometerData* data)
 //{
-//    HAL_GPIO_WritePin(DROGUE_PARACHUTE_TEMP_GPIO_Port, DROGUE_PARACHUTE_TEMP_Pin, GPIO_PIN_RESET);
+//    if (osMutexWait(data->mutex_, 0) != osOK)
+//    {
+//        return -1;
+//    }
+//
+//    int32_t pressure = data->pressure_;
+//    osMutexRelease(data->mutex_);
+//
+//    return (int32_t)pressure;
 //}
-
-void ejectMainParachute()
-{
-//    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_SET);  // high signal causes high current to ignite e-match
-}
-
-void closeMainParachute()
-{
-//    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_RESET);
-}
-
-
-/**
- * This routine just waits for the current flight phase to get out of PRELAUNCH
- */
-void parachutesControlPrelaunchRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        if (getCurrentFlightPhase() != PRELAUNCH)
-        {
-            // Ascent has begun
-            return;
-        }
-    }
-}
-
-void parachutesControlBurnRoutine(
-    AccelGyroMagnetismData* accelGyroMagnetismData,
-    BarometerData* barometerData
-)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        if (getCurrentFlightPhase() != BURN)
-        {
-            return;
-        }
-
-        int32_t currentAccel = readAccel(accelGyroMagnetismData);
-        int32_t currentPressure = readPressure(barometerData);
-
-        if (currentAccel == -1 || currentPressure == -1)
-        {
-            // failed to read values
-            continue;
-        }
-
-        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
-    }
-}
-
-
-/**
- * This routine monitors for apogee.
- * Once apogee has been detected,
- * eject the drogue parachute and update the current flight phase.
- */
-void parachutesControlCoastRoutine(
-    AccelGyroMagnetismData* accelGyroMagnetismData,
-    BarometerData* barometerData
-)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t elapsedTime = 0;
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
-
-        int32_t currentAccel = readAccel(accelGyroMagnetismData);
-        int32_t currentPressure = readPressure(barometerData);
-
-        if (currentAccel == -1 || currentPressure == -1)
-        {
-            // failed to read values
-            continue;
-        }
-
-        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        if (detectApogee(kalmanFilterState) || elapsedTime > KALMAN_FILTER_DROGUE_TIMEOUT)
-        {
-            //ejectDrogueParachute();
-            newFlightPhase(DROGUE_DESCENT);
-            return;
-        }
-    }
-}
-
-/**
- * This routine detects reaching a certain altitude
- * Once that altitude has been reached, eject the main parachute
- * and update the current flight phase.
- */
-void parachutesControlDrogueDescentRoutine(
-    AccelGyroMagnetismData* accelGyroMagnetismData,
-    BarometerData* barometerData
-)
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t elapsedTime = 0;
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
-
-        if (elapsedTime > PARACHUTE_PULSE_DURATION)
-        {
-            //closeDrogueParachute();
-        }
-
-        int32_t currentAccel = readAccel(accelGyroMagnetismData);
-        int32_t currentPressure = readPressure(barometerData);
-
-        if (currentAccel == -1 || currentPressure == -1)
-        {
-            // failed to read values
-            continue;
-        }
-
-        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        // detect 4600 ft above sea level and eject main parachute
-        if (detectMainDeploymentAltitude(kalmanFilterState) || elapsedTime > KALMAN_FILTER_MAIN_TIMEOUT)
-        {
-            ejectMainParachute();
-            newFlightPhase(MAIN_DESCENT);
-            return;
-        }
-    }
-}
-
-// this task just ensures the gpios for the parachutes are turned off after 3 seconds
-void parachutesControlMainDescentRoutine()
-{
-    uint32_t prevWakeTime = osKernelSysTick();
-    uint32_t elapsedTime = 0;
-
-    for (;;)
-    {
-        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
-
-        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
-
-        if (elapsedTime > PARACHUTE_PULSE_DURATION)
-        {
-            //closeDrogueParachute();
-            closeMainParachute();
-        }
-    }
-}
-
-void parachutesControlTask(void const* arg)
-{
-    ParachutesControlData* data = (ParachutesControlData*) arg;
-    kalmanFilterState.altitude = SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL;
-    kalmanFilterState.velocity = 0;
-    kalmanFilterState.acceleration = 0;
-
-    for (;;)
-    {
-        switch (getCurrentFlightPhase())
-        {
-            case PRELAUNCH:
-            case ARM:
-                parachutesControlPrelaunchRoutine();
-                break;
-
-            case BURN:
-                parachutesControlBurnRoutine(
-                    data->accelGyroMagnetismData_,
-                    data->barometerData_
-                );
-                break;
-
-            case COAST:
-                parachutesControlCoastRoutine(
-                    data->accelGyroMagnetismData_,
-                    data->barometerData_
-                );
-                break;
-
-            case DROGUE_DESCENT:
-                parachutesControlDrogueDescentRoutine(
-                    data->accelGyroMagnetismData_,
-                    data->barometerData_
-                );
-
-                break;
-
-            case MAIN_DESCENT:
-                parachutesControlMainDescentRoutine();
-                break;
-
-            case ABORT_COMMAND_RECEIVED:
-            case ABORT_OXIDIZER_PRESSURE:
-            case ABORT_UNSPECIFIED_REASON:
-            case ABORT_COMMUNICATION_ERROR:
-                // do nothing
-                osDelay(MONITOR_FOR_PARACHUTES_PERIOD);
-                break;
-
-            default:
-                break;
-        }
-    }
-}
+//
+//
+//
+///**
+// * Takes an old state vector and current state measurements and
+// * converts them into a prediction of the rocket's current state.
+// *
+// * Params:
+// *   oldState - (KalmanStateVector) Past altitude, velocity and acceleration
+// *   currentAccel - (double) Measured acceleration
+// *   currentAltitude - (double) Measured altitude
+// *   dt - (double) Time since last step. In ms.
+// *
+// * Returns:
+// *   newState - (KalmanStateVector) Current altitude, velocity and acceleration
+// */
+//struct KalmanStateVector filterSensors(
+//    struct KalmanStateVector oldState,
+//    int32_t currentAccel,
+//    int32_t currentPressure,
+//    double dtMillis
+//)
+//{
+//    struct KalmanStateVector newState;
+//
+//    double accelIn = (double) currentAccel / 1000 * 9.8; // Milli-g -> g -> m/s
+//
+//    // Convert from 100*millibars to m. This may or may not be right, depending on where you look. Needs testing
+//    double altIn = (double) 44307.69396 * (1 - pow(currentPressure / SEA_LEVEL_PRESSURE, 0.190284));
+//
+//    // Convert from ms to s
+//    double dt = dtMillis / 1000;
+//
+//
+//    // Propagate old state using simple kinematics equations
+//    newState.altitude = oldState.altitude + oldState.velocity * dt + 0.5 * dt * dt * oldState.acceleration;
+//    newState.velocity = oldState.velocity + oldState.acceleration * dt;
+//    newState.acceleration = oldState.acceleration;
+//
+//    // Calculate the difference between the new state and the measurements
+//    double baroDifference = altIn - newState.altitude;
+//    double accelDifference = accelIn - newState.acceleration;
+//
+//    // Minimize the chi2 error by means of the Kalman gain matrix
+//    newState.altitude = newState.altitude + KALMAN_GAIN[0][0] * baroDifference + KALMAN_GAIN[0][1] * accelDifference;
+//    newState.velocity = newState.velocity + KALMAN_GAIN[1][0] * baroDifference + KALMAN_GAIN[1][1] * accelDifference;
+//    newState.acceleration = newState.velocity + KALMAN_GAIN[2][0] * baroDifference + KALMAN_GAIN[2][1] * accelDifference;
+//
+//    return newState;
+//}
+//
+///**
+// * Takes the current state vector and determines if apogee has been reached.
+// *
+// * Params:
+// *   state - (KalmanStateVector) Past altitude, velocity and acceleration
+// *
+// * Returns:
+// *   - (int32_t) 1 if apogee has been reached, 0 if not.
+// */
+//int32_t detectApogee(struct KalmanStateVector state)
+//{
+//    // Monitor for when to deploy drogue chute. Simple velocity tolerance, looking for a minimum.
+//    if (state.velocity < 10)
+//    {
+//        return 1;
+//    }
+//
+//    return 0;
+//}
+//
+///**
+// * Takes the current state vector and determines if main chute should be released.
+// *
+// * ***NOTE: This is determined by the constant MAIN_DEPLOYMENT_ALTITUDE,
+// *           which should be verified before launch.
+// *
+// * Params:
+// *   state - (KalmanStateVector) Past altitude, velocity and acceleration
+// *
+// * Returns:
+// *   - (int32_t) 1 if main chute should be deployed, 0 if not.
+// */
+//int32_t detectMainDeploymentAltitude(struct KalmanStateVector state)
+//{
+//    // Monitor for when to deploy main chute. Simply look for less than desired altitude.
+//    if (state.altitude < MAIN_DEPLOYMENT_ALTITUDE)
+//    {
+//        return 1;
+//    }
+//
+//    return 0;
+//}
+//
+////void ejectDrogueParachute()
+////{
+////    HAL_GPIO_WritePin(DROGUE_PARACHUTE_TEMP_GPIO_Port, DROGUE_PARACHUTE_TEMP_Pin, GPIO_PIN_SET);  // high signal causes high current to ignite e-match
+////}
+////
+////void closeDrogueParachute()
+////{
+////    HAL_GPIO_WritePin(DROGUE_PARACHUTE_TEMP_GPIO_Port, DROGUE_PARACHUTE_TEMP_Pin, GPIO_PIN_RESET);
+////}
+//
+//void ejectMainParachute()
+//{
+////    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_SET);  // high signal causes high current to ignite e-match
+//}
+//
+//void closeMainParachute()
+//{
+////    HAL_GPIO_WritePin(MAIN_PARACHUTE_GPIO_Port, MAIN_PARACHUTE_Pin, GPIO_PIN_RESET);
+//}
+//
+//
+///**
+// * This routine just waits for the current flight phase to get out of PRELAUNCH
+// */
+//void parachutesControlPrelaunchRoutine()
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+//
+//        if (getCurrentFlightPhase() != PRELAUNCH)
+//        {
+//            // Ascent has begun
+//            return;
+//        }
+//    }
+//}
+//
+//void parachutesControlBurnRoutine(
+//    AccelGyroMagnetismData* accelGyroMagnetismData,
+//    BarometerData* barometerData
+//)
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+//
+//        if (getCurrentFlightPhase() != BURN)
+//        {
+//            return;
+//        }
+//
+//        int32_t currentAccel = readAccel(accelGyroMagnetismData);
+//        int32_t currentPressure = readPressure(barometerData);
+//
+//        if (currentAccel == -1 || currentPressure == -1)
+//        {
+//            // failed to read values
+//            continue;
+//        }
+//
+//        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
+//    }
+//}
+//
+//
+///**
+// * This routine monitors for apogee.
+// * Once apogee has been detected,
+// * eject the drogue parachute and update the current flight phase.
+// */
+//void parachutesControlCoastRoutine(
+//    AccelGyroMagnetismData* accelGyroMagnetismData,
+//    BarometerData* barometerData
+//)
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//    uint32_t elapsedTime = 0;
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+//
+//        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
+//
+//        int32_t currentAccel = readAccel(accelGyroMagnetismData);
+//        int32_t currentPressure = readPressure(barometerData);
+//
+//        if (currentAccel == -1 || currentPressure == -1)
+//        {
+//            // failed to read values
+//            continue;
+//        }
+//
+//        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
+//
+//        if (detectApogee(kalmanFilterState) || elapsedTime > KALMAN_FILTER_DROGUE_TIMEOUT)
+//        {
+//            //ejectDrogueParachute();
+//            newFlightPhase(DROGUE_DESCENT);
+//            return;
+//        }
+//    }
+//}
+//
+///**
+// * This routine detects reaching a certain altitude
+// * Once that altitude has been reached, eject the main parachute
+// * and update the current flight phase.
+// */
+//void parachutesControlDrogueDescentRoutine(
+//    AccelGyroMagnetismData* accelGyroMagnetismData,
+//    BarometerData* barometerData
+//)
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//    uint32_t elapsedTime = 0;
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+//
+//        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
+//
+//        if (elapsedTime > PARACHUTE_PULSE_DURATION)
+//        {
+//            //closeDrogueParachute();
+//        }
+//
+//        int32_t currentAccel = readAccel(accelGyroMagnetismData);
+//        int32_t currentPressure = readPressure(barometerData);
+//
+//        if (currentAccel == -1 || currentPressure == -1)
+//        {
+//            // failed to read values
+//            continue;
+//        }
+//
+//        filterSensors(kalmanFilterState, currentAccel, currentPressure, MONITOR_FOR_PARACHUTES_PERIOD);
+//
+//        // detect 4600 ft above sea level and eject main parachute
+//        if (detectMainDeploymentAltitude(kalmanFilterState) || elapsedTime > KALMAN_FILTER_MAIN_TIMEOUT)
+//        {
+//            ejectMainParachute();
+//            newFlightPhase(MAIN_DESCENT);
+//            return;
+//        }
+//    }
+//}
+//
+//// this task just ensures the gpios for the parachutes are turned off after 3 seconds
+//void parachutesControlMainDescentRoutine()
+//{
+//    uint32_t prevWakeTime = osKernelSysTick();
+//    uint32_t elapsedTime = 0;
+//
+//    for (;;)
+//    {
+//        osDelayUntil(&prevWakeTime, MONITOR_FOR_PARACHUTES_PERIOD);
+//
+//        elapsedTime += MONITOR_FOR_PARACHUTES_PERIOD;
+//
+//        if (elapsedTime > PARACHUTE_PULSE_DURATION)
+//        {
+//            //closeDrogueParachute();
+//            closeMainParachute();
+//        }
+//    }
+//}
+//
+//void parachutesControlTask(void const* arg)
+//{
+//    ParachutesControlData* data = (ParachutesControlData*) arg;
+//    kalmanFilterState.altitude = SPACE_PORT_AMERICA_ALTITUDE_ABOVE_SEA_LEVEL;
+//    kalmanFilterState.velocity = 0;
+//    kalmanFilterState.acceleration = 0;
+//
+//    for (;;)
+//    {
+//        switch (getCurrentFlightPhase())
+//        {
+//            case PRELAUNCH:
+//            case ARM:
+//                parachutesControlPrelaunchRoutine();
+//                break;
+//
+//            case BURN:
+//                parachutesControlBurnRoutine(
+//                    data->accelGyroMagnetismData_,
+//                    data->barometerData_
+//                );
+//                break;
+//
+//            case COAST:
+//                parachutesControlCoastRoutine(
+//                    data->accelGyroMagnetismData_,
+//                    data->barometerData_
+//                );
+//                break;
+//
+//            case DROGUE_DESCENT:
+//                parachutesControlDrogueDescentRoutine(
+//                    data->accelGyroMagnetismData_,
+//                    data->barometerData_
+//                );
+//
+//                break;
+//
+//            case MAIN_DESCENT:
+//                parachutesControlMainDescentRoutine();
+//                break;
+//
+//            case ABORT_COMMAND_RECEIVED:
+//            case ABORT_OXIDIZER_PRESSURE:
+//            case ABORT_UNSPECIFIED_REASON:
+//            case ABORT_COMMUNICATION_ERROR:
+//                // do nothing
+//                osDelay(MONITOR_FOR_PARACHUTES_PERIOD);
+//                break;
+//
+//            default:
+//                break;
+//        }
+//    }
+//}

--- a/Core/Src/ReadAccelGyroMagnetism.c
+++ b/Core/Src/ReadAccelGyroMagnetism.c
@@ -56,29 +56,29 @@ void readAccelGyroMagnetismTask(void const* arg)
     osDelay(1000);
 
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, &READ_GYRO_X_G_LOW_CMD, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&IMU_SPI, &READ_GYRO_X_G_LOW_CMD, 1, CMD_TIMEOUT);
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
 
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_GYRO_ACCEL_CMD, 1, CMD_TIMEOUT);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_GYRO_ACCEL_DATA, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&IMU_SPI, &ACTIVATE_GYRO_ACCEL_CMD, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&IMU_SPI, &ACTIVATE_GYRO_ACCEL_DATA, 1, CMD_TIMEOUT);
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
 
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, &SET_ACCEL_SCALE_CMD, 1, CMD_TIMEOUT);
-    HAL_SPI_Transmit(&hspi1, &SET_ACCEL_SCALE_DATA, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&IMU_SPI, &SET_ACCEL_SCALE_CMD, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&IMU_SPI, &SET_ACCEL_SCALE_DATA, 1, CMD_TIMEOUT);
     HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
 
     HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_MAGNETO_CMD, 1, CMD_TIMEOUT);
-    HAL_SPI_Transmit(&hspi1, &ACTIVATE_MAGNETO_DATA, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&IMU_SPI, &ACTIVATE_MAGNETO_CMD, 1, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&IMU_SPI, &ACTIVATE_MAGNETO_DATA, 1, CMD_TIMEOUT);
     HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
 
     /* Read WHO AM I register for verification, should read 104. */
     // uint8_t whoami;
     // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
-    // HAL_SPI_Transmit(&hspi1, &READ_WHOAMIM_CMD, 1, CMD_TIMEOUT);
-    // HAL_SPI_Receive(&hspi1, &whoami, 1, CMD_TIMEOUT);
+    // HAL_SPI_Transmit(&IMU_SPI, &READ_WHOAMIM_CMD, 1, CMD_TIMEOUT);
+    // HAL_SPI_Receive(&IMU_SPI, &whoami, 1, CMD_TIMEOUT);
     // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
 
     uint8_t dataBuffer[6];
@@ -93,24 +93,24 @@ void readAccelGyroMagnetismTask(void const* arg)
 
         //READ------------------------------------------------------
         HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi1, &READ_GYRO_X_G_LOW_CMD, 1, CMD_TIMEOUT);
-        HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
+        HAL_SPI_Transmit(&IMU_SPI, &READ_GYRO_X_G_LOW_CMD, 1, CMD_TIMEOUT);
+        HAL_SPI_Receive(&IMU_SPI, &dataBuffer[0], 6, CMD_TIMEOUT);
         HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
         gyroX = (dataBuffer[1] << 8) | (dataBuffer[0]);
         gyroY = (dataBuffer[3] << 8) | (dataBuffer[2]);
         gyroZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
 
         HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi1, &READ_ACCEL_X_LOW_CMD, 1, CMD_TIMEOUT);
-        HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
+        HAL_SPI_Transmit(&IMU_SPI, &READ_ACCEL_X_LOW_CMD, 1, CMD_TIMEOUT);
+        HAL_SPI_Receive(&IMU_SPI, &dataBuffer[0], 6, CMD_TIMEOUT);
         HAL_GPIO_WritePin(IMU_CS_GPIO_Port, IMU_CS_Pin, GPIO_PIN_SET);
         accelX = (dataBuffer[1] << 8) | (dataBuffer[0]);
         accelY = (dataBuffer[3] << 8) | (dataBuffer[2]);
         accelZ = (dataBuffer[5] << 8) | (dataBuffer[4]);
 
         // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_RESET);
-        // HAL_SPI_Transmit(&hspi1, &READ_MAGNETO_X_LOW_CMD, 1, CMD_TIMEOUT);
-        // HAL_SPI_Receive(&hspi1, &dataBuffer[0], 6, CMD_TIMEOUT);
+        // HAL_SPI_Transmit(&IMU_SPI, &READ_MAGNETO_X_LOW_CMD, 1, CMD_TIMEOUT);
+        // HAL_SPI_Receive(&IMU_SPI, &dataBuffer[0], 6, CMD_TIMEOUT);
         // HAL_GPIO_WritePin(MAG_CS_GPIO_Port, MAG_CS_Pin, GPIO_PIN_SET);
         // magnetoX = (dataBuffer[1] << 8) | (dataBuffer[0]);
         // magnetoY = (dataBuffer[3] << 8) | (dataBuffer[2]);

--- a/Core/Src/ReadAccelGyroMagnetism.c
+++ b/Core/Src/ReadAccelGyroMagnetism.c
@@ -3,8 +3,7 @@
 #include "cmsis_os.h"
 
 #include "ReadAccelGyroMagnetism.h"
-
-#include "Data.h"
+#include "Globals.h"
 
 static int READ_ACCEL_GYRO_MAGNETISM = 25;
 

--- a/Core/Src/ReadBarometer.c
+++ b/Core/Src/ReadBarometer.c
@@ -92,7 +92,7 @@ void readBarometerTask(void const* arg)
 
     // Reset the barometer
     HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi3, &RESET_CMD, CMD_SIZE, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&BARO_SPI, &RESET_CMD, CMD_SIZE, CMD_TIMEOUT);
     osDelay(3); // 2.8ms reload after Reset command
     HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
 
@@ -117,25 +117,25 @@ void readBarometerTask(void const* arg)
 
         // Tell the barometer to convert the pressure to a digital value with an over-sampling ratio of 512
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi3, &ADC_D1_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_Transmit(&BARO_SPI, &ADC_D1_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
 
         osDelay(2); // 1.17ms max conversion time for an over-sampling ratio of 512
 
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
 
-        HAL_SPI_Transmit(&hspi3, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_Transmit(&BARO_SPI, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
 
         // Read the first byte (bits 23-16)
-        HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_TransmitReceive(&BARO_SPI, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
         pressureReading = dataInBuffer << 16;
 
         // Read the second byte (bits 15-8)
-        HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_TransmitReceive(&BARO_SPI, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
         pressureReading += dataInBuffer << 8;
 
         // Read the third byte (bits 7-0)
-        HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_TransmitReceive(&BARO_SPI, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
         pressureReading += dataInBuffer;
 
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
@@ -144,25 +144,25 @@ void readBarometerTask(void const* arg)
 
         // Tell the barometer to convert the temperature to a digital value with an over-sampling ratio of 512
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
-        HAL_SPI_Transmit(&hspi3, &ADC_D2_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_Transmit(&BARO_SPI, &ADC_D2_512_CONV_CMD, CMD_SIZE, CMD_TIMEOUT);
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
 
         osDelay(2); // 1.17ms max conversion time for an over-sampling ratio of 512
 
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
 
-        HAL_SPI_Transmit(&hspi3, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_Transmit(&BARO_SPI, &ADC_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
 
         // Read the first byte (bits 23-16)
-        HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_TransmitReceive(&BARO_SPI, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
         temperatureReading = dataInBuffer << 16;
 
         // Read the second byte (bits 15-8)
-        HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_TransmitReceive(&BARO_SPI, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
         temperatureReading += dataInBuffer << 8;
 
         // Read the third byte (bits 7-0)
-        HAL_SPI_TransmitReceive(&hspi3, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+        HAL_SPI_TransmitReceive(&BARO_SPI, &ADC_READ_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
         temperatureReading += dataInBuffer;
 
         HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);
@@ -226,14 +226,14 @@ uint16_t readCalibrationCoefficient(const uint8_t PROM_READ_CMD)
 
     HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_RESET);
 
-    HAL_SPI_Transmit(&hspi3, &PROM_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
+    HAL_SPI_Transmit(&BARO_SPI, &PROM_READ_CMD, CMD_SIZE, CMD_TIMEOUT);
 
     // Read the first byte (bits 15-8)
-    HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    HAL_SPI_TransmitReceive(&BARO_SPI, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
     coefficient = dataInBuffer << 8;
 
     // Read the second byte (bits 7-0)
-    HAL_SPI_TransmitReceive(&hspi3, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
+    HAL_SPI_TransmitReceive(&BARO_SPI, &READ_BYTE_CMD, &dataInBuffer, CMD_SIZE, CMD_TIMEOUT);
     coefficient += dataInBuffer;
 
     HAL_GPIO_WritePin(BARO_CS_GPIO_Port, BARO_CS_Pin, GPIO_PIN_SET);

--- a/Core/Src/ReadBarometer.c
+++ b/Core/Src/ReadBarometer.c
@@ -16,7 +16,7 @@
 #include "cmsis_os.h"
 
 #include "ReadBarometer.h"
-#include "Data.h"
+#include "Globals.h"
 
 /* Macros --------------------------------------------------------------------*/
 

--- a/Core/Src/ReadCombustionChamberPressure.c
+++ b/Core/Src/ReadCombustionChamberPressure.c
@@ -4,8 +4,7 @@
 #include "math.h"
 
 #include "ReadCombustionChamberPressure.h"
-
-#include "Data.h"
+#include "Globals.h"
 #include "Utils.h"
 
 #define QUEUE_SIZE 5

--- a/Core/Src/ReadCombustionChamberPressure.c
+++ b/Core/Src/ReadCombustionChamberPressure.c
@@ -28,15 +28,15 @@ void readCombustionChamberPressureTask(void const* arg)
 
     int combustionChamberQueueIndex = 0;
 
-    HAL_ADC_Start(&hadc1);  // Enables ADC and starts conversion of regular channels
+    HAL_ADC_Start(&COMBINED_ADC);  // Enables ADC and starts conversion of regular channels
 
     for (;;)
     {
         osDelayUntil(&prevWakeTime, READ_COMBUSTION_CHAMBER_PRESSURE_PERIOD);
 
-        if (HAL_ADC_PollForConversion(&hadc1, COMBUSTION_CHAMBER_ADC_POLL_TIMEOUT) == HAL_OK)
+        if (HAL_ADC_PollForConversion(&COMBINED_ADC, COMBUSTION_CHAMBER_ADC_POLL_TIMEOUT) == HAL_OK)
         {
-            combustionChamberValuesQueue[combustionChamberQueueIndex++] = HAL_ADC_GetValue(&hadc1);
+            combustionChamberValuesQueue[combustionChamberQueueIndex++] = HAL_ADC_GetValue(&COMBINED_ADC);
         }
 
         uint16_t adcRead = averageArray(combustionChamberValuesQueue, QUEUE_SIZE);

--- a/Core/Src/ReadGps.c
+++ b/Core/Src/ReadGps.c
@@ -3,7 +3,6 @@
 #include "cmsis_os.h"
 
 #include "ReadGps.h"
-#include "Globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,7 +15,7 @@ void readGpsTask(void const* arg)
     GpsData* data = (GpsData*) arg;
     uint32_t prevWakeTime = osKernelSysTick();
 
-    HAL_UART_Receive_DMA(&huart4, (uint8_t*) &dma_rx_buffer, NMEA_MAX_LENGTH + 1);
+    HAL_UART_Receive_DMA(&GPS_UART, (uint8_t*) &dma_rx_buffer, NMEA_MAX_LENGTH + 1);
 
     for (;;)
     {

--- a/Core/Src/ReadGps.c
+++ b/Core/Src/ReadGps.c
@@ -3,8 +3,7 @@
 #include "cmsis_os.h"
 
 #include "ReadGps.h"
-
-#include "Data.h"
+#include "Globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/Core/Src/ReadOxidizerTankPressure.c
+++ b/Core/Src/ReadOxidizerTankPressure.c
@@ -26,15 +26,15 @@ void readOxidizerTankPressureTask(void const* arg)
 
     int oxidizerTankQueueIndex = 0;
 
-    HAL_ADC_Start(&hadc2);  // Enables ADC and starts conversion of regular channels
+    HAL_ADC_Start(&COMBINED_ADC);  // Enables ADC and starts conversion of regular channels
 
     for (;;)
     {
         osDelayUntil(&prevWakeTime, READ_OXIDIZER_TANK_PRESSURE_PERIOD);
 
-        if (HAL_ADC_PollForConversion(&hadc2, OXIDIZER_TANK_POLL_TIMEOUT) == HAL_OK)
+        if (HAL_ADC_PollForConversion(&COMBINED_ADC, OXIDIZER_TANK_POLL_TIMEOUT) == HAL_OK)
         {
-            oxidizerTankValuesQueue[oxidizerTankQueueIndex++] = HAL_ADC_GetValue(&hadc2);
+            oxidizerTankValuesQueue[oxidizerTankQueueIndex++] = HAL_ADC_GetValue(&COMBINED_ADC);
         }
 
         uint16_t adcRead = averageArray(oxidizerTankValuesQueue, QUEUE_SIZE);

--- a/Core/Src/ReadOxidizerTankPressure.c
+++ b/Core/Src/ReadOxidizerTankPressure.c
@@ -4,8 +4,7 @@
 #include "math.h"
 
 #include "ReadOxidizerTankPressure.h"
-
-#include "Data.h"
+#include "Globals.h"
 #include "Utils.h"
 
 #define QUEUE_SIZE 5

--- a/Core/Src/TransmitData.c
+++ b/Core/Src/TransmitData.c
@@ -140,13 +140,13 @@ void transmitImuData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     //Encode the message and send it to ground systems and radio
     encodeMessage(message, IMU_SERIAL_MSG_SIZE, buffer);
-
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 
@@ -184,12 +184,13 @@ void transmitBarometerData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, BAROMETER_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 
@@ -248,12 +249,13 @@ void transmitGpsData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, GPS_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 
@@ -288,12 +290,13 @@ void transmitOxidizerTankData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, OXIDIZER_TANK_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 
@@ -328,12 +331,13 @@ void transmitCombustionChamberData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, COMBUSTION_CHAMBER_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 
@@ -359,12 +363,13 @@ void transmitFlightPhaseData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, ONE_BYTE_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 
@@ -389,12 +394,13 @@ void transmitInjectionValveStatus()
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, ONE_BYTE_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 
@@ -419,12 +425,13 @@ void transmitLowerVentValveStatus()
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, ONE_BYTE_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
+    FlightPhase currFlightPhase = getCurrentFlightPhase();
+    if (currFlightPhase == PRELAUNCH || currFlightPhase == ARM || currFlightPhase == BURN || isAbortPhase() )
     {
-        HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
+        HAL_UART_Transmit(&GS_UART, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
     }
 
-    HAL_UART_Transmit(&huart1, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
+    HAL_UART_Transmit(&RADIO_UART, &buffer, sizeof(buffer), UART_TIMEOUT);  // Radio
     free(buffer);
 }
 

--- a/Core/Src/TransmitData.c
+++ b/Core/Src/TransmitData.c
@@ -1,11 +1,11 @@
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_conf.h"
 #include "cmsis_os.h"
+
+#include "Globals.h"
 #include "TransmitData.h"
 #include "Utils.h"
 #include "FlightPhase.h"
-#include "Data.h"
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -141,7 +141,7 @@ void transmitImuData(AllData* data)
     //Encode the message and send it to ground systems and radio
     encodeMessage(message, IMU_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
@@ -184,7 +184,7 @@ void transmitBarometerData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, BAROMETER_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
@@ -248,7 +248,7 @@ void transmitGpsData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, GPS_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
     }
@@ -288,7 +288,7 @@ void transmitOxidizerTankData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, OXIDIZER_TANK_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
@@ -328,7 +328,7 @@ void transmitCombustionChamberData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, COMBUSTION_CHAMBER_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
@@ -359,7 +359,7 @@ void transmitFlightPhaseData(AllData* data)
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, ONE_BYTE_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT);  // Ground Systems
     }
@@ -389,7 +389,7 @@ void transmitInjectionValveStatus()
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, ONE_BYTE_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
     }
@@ -419,7 +419,7 @@ void transmitLowerVentValveStatus()
     uint8_t* buffer = malloc(bufferLength * sizeof(uint8_t));
     encodeMessage(message, ONE_BYTE_SERIAL_MSG_SIZE, buffer);
 
-    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (IS_ABORT_PHASE))
+    if ((getCurrentFlightPhase() == PRELAUNCH) || (getCurrentFlightPhase() == ARM) || (getCurrentFlightPhase() == BURN) || (isAbortPhase()))
     {
         HAL_UART_Transmit(&huart2, &buffer, sizeof(buffer), UART_TIMEOUT); // Ground Systems
     }
@@ -445,7 +445,6 @@ void transmitDataTask(void const* arg)
         transmitFlightPhaseData(data);
         transmitInjectionValveStatus();
         transmitLowerVentValveStatus();
-        HAL_UART_Receive_IT(&huart2, &launchSystemsRxChar, 1);
     }
 }
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -86,6 +86,10 @@ static osThreadId transmitDataTaskHandle;
 // Debug thread
 static osThreadId debugTaskHandle;
 
+// Flight phase threads
+static osThreadId flightPhaseTaskHandle;
+static osThreadId gsListenTaskHandle;
+static osThreadId debugTaskHandle;
 // Flight phases variables
 osMutexId flightPhaseMutex;
 xQueueHandle flightPhaseQueue; //queue to be passed to flight phase thread
@@ -320,7 +324,7 @@ int main(void)
         1,
         configMINIMAL_STACK_SIZE * 3
     );
-    logDataTaskHandle =
+    flightPhaseTaskHandle =
         osThreadCreate(osThread(flightPhaseThread), &flightPhaseQueue);
 
     osThreadDef(
@@ -330,7 +334,7 @@ int main(void)
         1,
         configMINIMAL_STACK_SIZE
     );
-    logDataTaskHandle =
+    gsListenTaskHandle =
         osThreadCreate(osThread(gsListenThread), NULL);
 
 //    if (HAL_GPIO_ReadPin(AUX1_GPIO_Port, AUX1_Pin) == 1) {

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -36,10 +36,10 @@
 #include "LogData.h"
 #include "TransmitData.h"
 #include "AbortPhase.h"
-#include "Data.h"
 #include "FlightPhase.h"
 #include "ValveControl.h"
 #include "Debug.h"
+#include "Globals.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -80,35 +80,19 @@ static osThreadId readBarometerTaskHandle;
 static osThreadId readCombustionChamberPressureTaskHandle;
 static osThreadId readGpsTaskHandle;
 static osThreadId readOxidizerTankPressureTaskHandle;
-// Controls that will perform actions
-static osThreadId monitorForEmergencyShutoffTaskHandle;
-static osThreadId engineControlTaskHandle;
-static osThreadId parachutesControlTaskHandle;
 // Storing data
 static osThreadId logDataTaskHandle;
 static osThreadId transmitDataTaskHandle;
-// Special abort thread
-static osThreadId abortPhaseTaskHandle;
 // Debug thread
 static osThreadId debugTaskHandle;
 
+// Flight phases variables
 osMutexId flightPhaseMutex;
-
-static const uint8_t LAUNCH_CMD_BYTE = 0x20;
-static const uint8_t ARM_CMD_BYTE = 0x21;
-static const uint8_t ABORT_CMD_BYTE = 0x2F;
-static const uint8_t RESET_AVIONICS_CMD_BYTE = 0x4F;
-static const uint8_t HEARTBEAT_BYTE = 0x46;
-static const uint8_t OPEN_INJECTION_VALVE = 0x2A;
-static const uint8_t CLOSE_INJECTION_VALVE = 0x2B;
-
-uint8_t launchSystemsRxChar = 0;
-uint8_t launchCmdReceived = 0;
-uint8_t abortCmdReceived = 0;
-uint8_t resetAvionicsCmdReceived = 0;
-
-const int32_t HEARTBEAT_TIMEOUT = 3 * 60 * 1000; // 3 minutes
-int32_t heartbeatTimer = 0; // Initalized to HEARTBEAT_TIMEOUT in MonitorForEmergencyShutoff thread
+xQueueHandle flightPhaseQueue; //queue to be passed to flight phase thread
+static const int FLIGHT_PHASE_QUEUE_SIZE = 10;
+// value to temporarily store received char from ground systems before submitting to queue
+// need to assess the char in ISR before deciding to place at front or back of queue
+uint8_t groundSystemsRxChar = 0;
 
 static const int FLIGHT_PHASE_DISPLAY_FREQ = 1000;
 static const int FLIGHT_PHASE_BLINK_FREQ = 100;
@@ -247,11 +231,10 @@ int main(void)
 
   /* USER CODE BEGIN RTOS_TIMERS */
     /* start timers, add new ones, ... */
-    HAL_UART_Receive_IT(&huart1, &launchSystemsRxChar, 1);
   /* USER CODE END RTOS_TIMERS */
 
   /* USER CODE BEGIN RTOS_QUEUES */
-  /* add queues, ... */
+    flightPhaseQueue = xQueueCreate(FLIGHT_PHASE_QUEUE_SIZE, sizeof(uint8_t));
   /* USER CODE END RTOS_QUEUES */
 
   /* Create the thread(s) */
@@ -311,36 +294,6 @@ int main(void)
         osThreadCreate(osThread(readOxidizerTankPressureThread), oxidizerTankPressureData);
 
     osThreadDef(
-        monitorForEmergencyShutoffThread,
-        monitorForEmergencyShutoffTask,
-        osPriorityHigh,
-        1,
-        configMINIMAL_STACK_SIZE
-    );
-    monitorForEmergencyShutoffTaskHandle =
-        osThreadCreate(osThread(monitorForEmergencyShutoffThread), accelGyroMagnetismData);
-
-    osThreadDef(
-        engineControlThread,
-        engineControlTask,
-        osPriorityNormal,
-        1,
-        configMINIMAL_STACK_SIZE * 2
-    );
-    engineControlTaskHandle =
-        osThreadCreate(osThread(engineControlThread), oxidizerTankPressureData);
-
-//    osThreadDef(
-//        parachutesControlThread,
-//        parachutesControlTask,
-//        osPriorityAboveNormal,
-//        1,
-//        configMINIMAL_STACK_SIZE * 2
-//    );
-//    parachutesControlTaskHandle =
-//        osThreadCreate(osThread(parachutesControlThread), parachutesControlData);
-
-    osThreadDef(
         logDataThread,
         logDataTask,
         osPriorityNormal,
@@ -361,14 +314,24 @@ int main(void)
         osThreadCreate(osThread(transmitDataThread), allData);
 
     osThreadDef(
-        abortPhaseThread,
-        abortPhaseTask,
+        flightPhaseThread,
+		flightPhaseTask,
+        osPriorityHigh,
+        1,
+        configMINIMAL_STACK_SIZE * 3
+    );
+    logDataTaskHandle =
+        osThreadCreate(osThread(flightPhaseThread), &flightPhaseQueue);
+
+    osThreadDef(
+        gsListenThread,
+		gsListenerTask,
         osPriorityHigh,
         1,
         configMINIMAL_STACK_SIZE
     );
-    abortPhaseTaskHandle =
-        osThreadCreate(osThread(abortPhaseThread), NULL);
+    logDataTaskHandle =
+        osThreadCreate(osThread(gsListenThread), NULL);
 
 //    if (HAL_GPIO_ReadPin(AUX1_GPIO_Port, AUX1_Pin) == 1) {
 //      osThreadDef(debugThread,debugTask,osPriorityHigh,1,configMINIMAL_STACK_SIZE);
@@ -904,49 +867,25 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef* huart)
 
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef* huart)
 {
+#ifdef ROCKET_TYPE_SOLID
     if (huart->Instance == USART2)
     {
-        if (launchSystemsRxChar == LAUNCH_CMD_BYTE)
-        {
-            if (ARM == getCurrentFlightPhase())
-            {
-                launchCmdReceived++;
-            }
-        }
-        else if (launchSystemsRxChar == ARM_CMD_BYTE)
-        {
-            if (PRELAUNCH == getCurrentFlightPhase())
-            {
-                newFlightPhase(ARM);
-            }
-        }
-        else if (launchSystemsRxChar == ABORT_CMD_BYTE)
-        {
-            abortCmdReceived = 1;
-        }
-        else if (launchSystemsRxChar == RESET_AVIONICS_CMD_BYTE)
-        {
-            resetAvionicsCmdReceived = 1;
-        }
-        else if (launchSystemsRxChar == HEARTBEAT_BYTE)
-        {
-            heartbeatTimer = HEARTBEAT_TIMEOUT;
-        }
-        else if (launchSystemsRxChar == OPEN_INJECTION_VALVE)
-        {
-            if (IS_ABORT_PHASE)
-            {
-                openInjectionValve();
-            }
-        }
-        else if (launchSystemsRxChar == CLOSE_INJECTION_VALVE)
-        {
-            if (IS_ABORT_PHASE)
-            {
-                closeInjectionValve();
-            }
-        }
+    	if (groundSystemsRxChar == ABORT_CMD_BYTE)
+    	{
+    		if(xQueueSendToFrontFromISR(flightPhaseQueue, &groundSystemsRxChar, pdFALSE) != pdPASS)
+    		{
+    			HAL_UART_Transmit(&huart5, (uint8_t *)"\n\nError sending to flight queue front\n\n", 39, 500);
+    		}
+    	}
+    	else
+    	{
+    		if(xQueueSendToBackFromISR(flightPhaseQueue, &groundSystemsRxChar, pdFALSE) != pdPASS)
+			{
+				HAL_UART_Transmit(&huart5, (uint8_t *)"\n\nError sending to flight queue back\n\n", 38, 500);
+			}
+    	}
     }
+#endif
     else if (huart->Instance == UART4)
     {
         static char rx_buffer[NMEA_MAX_LENGTH + 1];

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -950,7 +950,7 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef* huart)
             }
         }
 
-        HAL_UART_Receive_DMA(&huart4, (uint8_t*) &dma_rx_buffer, NMEA_MAX_LENGTH + 1);
+        HAL_UART_Receive_DMA(&GPS_UART, (uint8_t*) &dma_rx_buffer, NMEA_MAX_LENGTH + 1);
     }
 }
 /* USER CODE END 4 */


### PR DESCRIPTION
Implements new solid flight phases according to new state diagrams. 

Convert previous tasks, MonitorForEmergencyShutoff and AbortPhase into gsListenerTask and flightPhaseTask.

Comments out hybrid specific and unused tasks (i.e ParachuteControl, EngineControl).

Adds global definition for rocket type and peripherals in new Global.h file, includes contents of old data.h file.